### PR TITLE
[BLOCKED] ENG-24482 - Implement global error handler for controller actions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "craftcms/cms": "^4.0.0",
-    "lilt/lilt-connector-sdk-php": "ENG-24482",
+    "lilt/lilt-connector-sdk-php": "dev-update",
     "ext-json": "*",
     "php": "^8.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "craftcms/cms": "^4.0.0",
-    "lilt/lilt-connector-sdk-php": "0.1.0",
+    "lilt/lilt-connector-sdk-php": "ENG-24482",
     "ext-json": "*",
     "php": "^8.0"
   },

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     platform: linux/x86_64
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: 1
-      MYSQL_DATABASE: ${DB_DATABASE}
+      MYSQL_DATABASE: "craft-lilt"
       MYSQL_USER: "craft-lilt"
       MYSQL_PASSWORD: "craft-lilt"
     networks:

--- a/src/Craftliltplugin.php
+++ b/src/Craftliltplugin.php
@@ -120,13 +120,6 @@ use yii\web\Response;
  */
 class Craftliltplugin extends Plugin
 {
-    /**
-     * A developer-side flag to control remote logging.
-     * If true, only `LiltLogger::error()` will send logs to the remote API.
-     * All log levels will still be written to local Craft logs.
-     */
-    public const REMOTE_LOG_ERRORS_ONLY = true;
-
     // Static Properties
     // =========================================================================
 
@@ -137,6 +130,13 @@ class Craftliltplugin extends Plugin
      * @var Craftliltplugin
      */
     public static $plugin;
+
+    /**
+     * A developer-side flag to control remote logging.
+     * If true, only `LiltLogger::error()` will send logs to the remote API.
+     * All log levels will still be written to local Craft logs.
+     */
+    public static bool $REMOTE_LOG_ERRORS_ONLY = true;
 
     // Public Properties
     // =========================================================================

--- a/src/Craftliltplugin.php
+++ b/src/Craftliltplugin.php
@@ -254,14 +254,16 @@ class Craftliltplugin extends Plugin
         // Run queue manager
         $this->startQueueManagerHandler->handle();
 
-        LiltLogger::info(
-            Craft::t(
-                'craft-lilt-plugin',
-                '{name} plugin loaded',
-                ['name' => $this->name]
-            ),
-            __METHOD__
-        );
+        if (Craft::$app->env !== 'test') {
+            LiltLogger::info(
+                Craft::t(
+                    'craft-lilt-plugin',
+                    '{name} plugin loaded',
+                    ['name' => $this->name]
+                ),
+                __METHOD__
+            );
+        }
 
         Event::on(
             EntriesController::class,

--- a/src/Craftliltplugin.php
+++ b/src/Craftliltplugin.php
@@ -95,6 +95,7 @@ use yii\web\Response;
  * @property JobsApi $connectorJobsApi
  * @property TranslationsApi $connectorTranslationsApi
  * @property SettingsApi $connectorSettingsApi
+ * @property LogsApi $logsApi
  * @property LanguageMapper $languageMapper
  * @property ElementTranslatableContentProvider $elementTranslatableContentProvider
  * @property FieldContentProvider $fieldContentProvider

--- a/src/Craftliltplugin.php
+++ b/src/Craftliltplugin.php
@@ -37,13 +37,13 @@ use lilthq\craftliltplugin\services\handlers\LoadI18NHandler;
 use lilthq\craftliltplugin\services\handlers\PublishDraftHandler;
 use lilthq\craftliltplugin\services\handlers\RefreshJobStatusHandler;
 use lilthq\craftliltplugin\services\handlers\ResendJobHandler;
+use lilthq\craftliltplugin\services\handlers\ResolveTranslationsConnectorIds;
 use lilthq\craftliltplugin\services\handlers\SendJobToLiltConnectorHandler;
 use lilthq\craftliltplugin\services\handlers\SendTranslationToLiltConnectorHandler;
 use lilthq\craftliltplugin\services\handlers\StartQueueManagerHandler;
 use lilthq\craftliltplugin\services\handlers\SyncJobFromLiltConnectorHandler;
 use lilthq\craftliltplugin\services\handlers\TranslationFailedHandler;
 use lilthq\craftliltplugin\services\handlers\UpdateJobStatusHandler;
-use lilthq\craftliltplugin\services\handlers\ResolveTranslationsConnectorIds;
 use lilthq\craftliltplugin\services\listeners\ListenerRegister;
 use lilthq\craftliltplugin\services\mappers\LanguageMapper;
 use lilthq\craftliltplugin\services\providers\ConnectorConfigurationProvider;
@@ -120,6 +120,13 @@ use yii\web\Response;
  */
 class Craftliltplugin extends Plugin
 {
+    /**
+     * A developer-side flag to control remote logging.
+     * If true, only `LiltLogger::error()` will send logs to the remote API.
+     * All log levels will still be written to local Craft logs.
+     */
+    public const REMOTE_LOG_ERRORS_ONLY = true;
+
     // Static Properties
     // =========================================================================
 
@@ -247,7 +254,7 @@ class Craftliltplugin extends Plugin
         // Run queue manager
         $this->startQueueManagerHandler->handle();
 
-        Craft::info(
+        LiltLogger::info(
             Craft::t(
                 'craft-lilt-plugin',
                 '{name} plugin loaded',

--- a/src/LiltLogger.php
+++ b/src/LiltLogger.php
@@ -138,7 +138,7 @@ class LiltLogger
     {
         Craft::getLogger()->log($message, $level, $category);
 
-        if (Craftliltplugin::REMOTE_LOG_ERRORS_ONLY && $level !== Logger::LEVEL_ERROR) {
+        if (Craftliltplugin::$REMOTE_LOG_ERRORS_ONLY && $level !== Logger::LEVEL_ERROR) {
             return;
         }
 

--- a/src/LiltLogger.php
+++ b/src/LiltLogger.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * @link      https://github.com/lilt
+ * @copyright Copyright (c) 2025 Lilt Devs
+ */
+
+namespace lilthq\craftliltplugin;
+
+use Craft;
+use craft\db\Connection;
+use Throwable;
+use yii\base\NotSupportedException;
+use yii\log\Logger;
+
+/**
+ * Lilt Logger Utility
+ *
+ * A static wrapper around Craft's logger that provides a single point for handling
+ * both local and remote logging. It automatically enriches log messages with
+ * system and environment metadata and sends the logs to Plugin API.
+ *
+ * @package lilthq\craftliltplugin
+ * @since 1.0.0
+ */
+class LiltLogger
+{
+    /**
+     * Logs a message with the 'trace' level.
+     *
+     * @param string|array $message The message to be logged.
+     * @param string $category The log category.
+     */
+    public static function debug(string|array $message, string $category = 'application'): void
+    {
+        static::log($message, Logger::LEVEL_TRACE, $category);
+    }
+
+    /**
+     * Logs a message with the 'info' level.
+     *
+     * @param string|array $message The message to be logged.
+     * @param string $category The log category.
+     */
+    public static function info(string|array $message, string $category = 'application'): void
+    {
+        static::log($message, Logger::LEVEL_INFO, $category);
+    }
+
+    /**
+     * Logs a message with the 'warning' level.
+     *
+     * @param string|array $message The message to be logged.
+     * @param string $category The log category.
+     */
+    public static function warning(string|array $message, string $category = 'application'): void
+    {
+        static::log($message, Logger::LEVEL_WARNING, $category);
+    }
+
+    /**
+     * Logs a message with the 'error' level.
+     *
+     * @param string|array $message The message to be logged.
+     * @param string $category The log category.
+     */
+    public static function error(string|array $message, string $category = 'application'): void
+    {
+        static::log($message, Logger::LEVEL_ERROR, $category);
+    }
+
+    /**
+     * Logs an exception with rich context.
+     *
+     * This method automatically extracts key information from the Throwable object,
+     * ensuring consistent and detailed error logging.
+     *
+     * @param Throwable $e The exception to log.
+     * @param array $metadata Additional metadata context for the exception.
+     * @param string $category The log category.
+     */
+    public static function logException(Throwable $e, array $metadata = [], string $category = 'application'): void
+    {
+        $message = array_merge([
+            'message' => $e->getMessage(),
+            'code' => $e->getCode(),
+            'file' => $e->getFile(),
+            'line' => $e->getLine(),
+            'trace' => $e->getTraceAsString(),
+        ], $metadata);
+
+        static::log($message, Logger::LEVEL_ERROR, $category);
+    }
+
+    /**
+     * Gathers general system and environment metadata for logging.
+     *
+     * @return array The collected system metadata.
+     */
+    private static function getSystemMetadata(): array
+    {
+        /** @var Connection $db */
+        $db = Craft::$app->getDb();
+
+        try {
+            $db_version = $db->getSchema()->getServerVersion();
+        } catch (NotSupportedException $ignored) {
+            $db_version = null;
+        }
+
+        return [
+            'craft_version' => Craft::$app->getVersion(),
+            'plugin_version' => Craftliltplugin::getInstance()->getVersion(),
+            'php_version' => PHP_VERSION,
+            'db_driver' => $db->driverName,
+            'db_version' => $db_version,
+            'environment' => Craft::$app->env,
+        ];
+    }
+
+    /**
+     * The core logging method.
+     *
+     * This method performs two actions:
+     * 1. Logs the message locally using Craft's built-in logger.
+     * 2. Sends the message and metadata to the remote Plugin API.
+     *
+     * Checks to see if `Craftliltplugin::REMOTE_LOG_ERRORS_ONLY == true` to determine if
+     * all logs or just error logs should be sent to the Plugin API. If the remote logging
+     * fails, that failure is logged locally.
+     *
+     * @param string|array $message The message to be logged.
+     * @param int $level The logging level (e.g., Logger::LEVEL_ERROR).
+     * @param string $category The log category.
+     * @see Craftliltplugin::REMOTE_LOG_ERRORS_ONLY
+     */
+    private static function log(string|array $message, int $level, string $category): void
+    {
+        Craft::getLogger()->log($message, $level, $category);
+
+        if (Craftliltplugin::REMOTE_LOG_ERRORS_ONLY && $level !== Logger::LEVEL_ERROR) {
+            return;
+        }
+
+        try {
+            $remoteMessage = is_string($message) ? $message : 'Craft CMS Error';
+            $metadata = self::getSystemMetadata();
+
+            if (is_array($message)) {
+                $metadata['payload'] = $message;
+            }
+
+            Craftliltplugin::getInstance()->logsApi->postLog(
+                $category,
+                $remoteMessage,
+                $metadata,
+            );
+        } catch (Throwable $e) {
+            // If the remote API logging fails, log that failure locally.
+            Craft::error(
+                'Failed to send log to Plugin API. Error: ' . $e->getMessage(),
+                __METHOD__
+            );
+        }
+    }
+}

--- a/src/controllers/GetReportDataController.php
+++ b/src/controllers/GetReportDataController.php
@@ -10,13 +10,14 @@ declare(strict_types=1);
 namespace lilthq\craftliltplugin\controllers;
 
 use Craft;
+use craft\helpers\Json;
 use lilthq\craftliltplugin\controllers\job\AbstractJobController;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\JobLogRecord;
 use lilthq\craftliltplugin\records\JobRecord;
 use lilthq\craftliltplugin\records\TranslationRecord;
 use Throwable;
 use yii\web\Response;
-use craft\helpers\Json;
 
 class GetReportDataController extends AbstractJobController
 {
@@ -105,7 +106,7 @@ class GetReportDataController extends AbstractJobController
         } catch (\Exception $e) {
             // Handle any exceptions that occur during the process
             $error = sprintf('An error occurred while downloading the files: %s', $e->getMessage());
-            Craft::error($error, __METHOD__);
+            LiltLogger::error($error, __METHOD__);
             die($error);
         }
     }

--- a/src/controllers/JobsController.php
+++ b/src/controllers/JobsController.php
@@ -10,11 +10,10 @@ declare(strict_types=1);
 namespace lilthq\craftliltplugin\controllers;
 
 use craft\helpers\UrlHelper;
-use craft\web\Controller;
 use lilthq\craftliltplugin\assets\JobsAsset;
 use yii\web\Response;
 
-class JobsController extends Controller
+class JobsController extends PluginController
 {
     public function actionIndex(): Response
     {

--- a/src/controllers/PluginController.php
+++ b/src/controllers/PluginController.php
@@ -9,10 +9,9 @@ declare(strict_types=1);
 
 namespace lilthq\craftliltplugin\controllers;
 
-use Craft;
 use craft\web\Controller;
-use lilthq\craftliltplugin\Craftliltplugin;
-use yii\base\Action;
+use lilthq\craftliltplugin\LiltLogger;
+use Throwable;
 
 /**
  * Plugin Controller
@@ -44,67 +43,20 @@ class PluginController extends Controller
      * @param string $id The ID of the action to be executed.
      * @param array $params The parameters to be passed to the action.
      * @return mixed The result of the action on success, or a JSON Response on failure.
+     * @throws Throwable The original exception caught.
      */
     public function runAction($id, $params = []): mixed
     {
         try {
             return parent::runAction($id, $params);
-        } catch (\Throwable $e) {
-            $this->handleError($e, $id, $params);
-
-            return $this->asJson([
-                'success' => false,
-                'message' => $e->getMessage(),
-            ]);
-        }
-    }
-
-    /**
-     * Handles and logs errors thrown caught from `beforeAction` and `runAction`.
-     *
-     * This method implements both local logging via `Craft::error` and remote logging
-     * to the Plugin API's POST /logs endpoint.
-     *
-     * If the Plugin API call fails, the failure will also be logged locally to ensure
-     * no error context is lost.
-     *
-     * @param \Throwable $e The thrown exception that occurred.
-     * @param string $event The ID of the action/event where the error occurred.
-     * @param array $params The parameters that were passed to the action.
-     */
-    private function handleError(\Throwable $e, string $event, array $params = []): void
-    {
-        $request = Craft::$app->getRequest();
-
-        Craft::error('Controller error: ' . json_encode([
-            'event' => $event,
-            'message' => $e->getMessage(),
-            'route' => $this->id . '/' . $event,
-            'method' => $request->getMethod(),
-        ]), __METHOD__);
-
-        try {
-            $metadata = [
-                'event' => $request->getMethod(),
-                'message' => $e->getMessage(),
-                'timestamp' => time(),
-                'body' => $request->getBodyParams() ?: $request->getQueryParams(),
+        } catch (Throwable $e) {
+            LiltLogger::logException($e, [
+                'event' => $id,
+                'route' => $this->getRoute(),
                 'params' => $params,
-            ];
+            ]);
 
-            Craftliltplugin::getInstance()->logsApi->postLog(
-                $event,
-                $e->getMessage(),
-                $metadata,
-            );
-        } catch (\Throwable $err) {
-            // If the remote API logging fails, log that failure locally.
-            Craft::error('Controller error: ' . json_encode([
-                'event' => $event,
-                'message' => $err->getMessage(),
-                'route' => $this->id . '/' . $event,
-                'method' => $request->getMethod(),
-            ]), __METHOD__);
+            throw $e;
         }
     }
 }

--- a/src/controllers/PluginController.php
+++ b/src/controllers/PluginController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace lilthq\craftliltplugin\controllers;
+
+use Craft;
+use craft\web\Controller;
+use lilthq\craftliltplugin\Craftliltplugin;
+use yii\base\Action;
+
+class PluginController extends Controller
+{
+    /**
+     * Catch any errors that occur before an action runs within a controller. If an error
+     * is caught, a log will be sent to Plugin API's POST /logs endpoint.
+     *
+     * @param Action $action the action to be executed.
+     * @return bool whether the action should continue to run or not.
+     */
+    public function beforeAction($action): bool
+    {
+        try {
+            return parent::beforeAction($action);
+        } catch (\Throwable $e) {
+            $this->handleError($e, $action->id);
+
+            return false;
+        }
+    }
+
+    /**
+     * Catch any errors that occur during an action being executed within a controller.
+     * If an error occurs, a log will be sent to Plugin API's POST /logs endpoint.
+     *
+     * @param string $id the ID of the action being executed.
+     * @param array $params the parameters passed to the action.
+     * @return mixed the result of the action.
+     */
+    public function runAction($id, $params = []): mixed
+    {
+        try {
+            return parent::runAction($id, $params);
+        } catch (\Throwable $e) {
+            $this->handleError($e, $id, $params);
+
+            return $this->asJson([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Handles errors that occur within beforeAction or runAction. This will trigger a
+     * Craft::error for server logs as well as send the log to Plugin API's POST /logs
+     * endpoint.
+     *
+     * @param \Throwable $e the thrown exception that occurred.
+     * @param string $event the ID of the event.
+     * @param array $params the parameters passed to the action.
+     */
+    private function handleError(\Throwable $e, string $event, array $params = []): void
+    {
+        $request = Craft::$app->getRequest();
+
+        Craft::error('Controller error: ' . json_encode([
+            'event' => $event,
+            'message' => $e->getMessage(),
+            'route' => $this->id . '/' . $event,
+            'method' => $request->getMethod(),
+        ]), __METHOD__);
+
+        try {
+            $metadata = [
+                'event' => __METHOD__,
+                'message' => $e->getMessage(),
+                'timestamp' => time(),
+                'body' => $request->getBodyParams() ?: $request->getQueryParams(),
+                'params' => $params,
+            ];
+
+            Craftliltplugin::getInstance()->logsApi->postLog(
+                $event,
+                $e->getMessage(),
+                $metadata,
+            );
+        } catch (\Throwable $ignored) {}
+    }
+}

--- a/src/controllers/PluginController.php
+++ b/src/controllers/PluginController.php
@@ -50,7 +50,12 @@ class PluginController extends Controller
         try {
             return parent::beforeAction($action);
         } catch (\Throwable $e) {
-            $this->handleError($e, $action->id);
+            $proofException = new \RuntimeException(
+                'PROOF_BEFORE_ACTION_CAUGHT: ' . $e->getMessage(),
+                $e->getCode(),
+                $e
+            );
+            $this->handleError($proofException, $action->id);
 
             // prevents the action from running.
             return false;

--- a/src/controllers/PluginController.php
+++ b/src/controllers/PluginController.php
@@ -71,7 +71,7 @@ class PluginController extends Controller
 
         try {
             $metadata = [
-                'event' => __METHOD__,
+                'event' => $request->getMethod(),
                 'message' => $e->getMessage(),
                 'timestamp' => time(),
                 'body' => $request->getBodyParams() ?: $request->getQueryParams(),

--- a/src/controllers/PluginController.php
+++ b/src/controllers/PluginController.php
@@ -18,12 +18,12 @@ use yii\base\Action;
  * Plugin Controller
  *
  * A base controller that extends craft\web\Controller. This provides centralized error
- * handling for all controllers that extend it, reporting any beforeAction and runAction
- * errors that occur back to the Plugin API.
+ * handling for all controllers that extend it, reporting any runAction errors that occur
+ * back to the Plugin API.
  *
- * It overrides the `beforeAction()` and `runAction()`, wrapping exectution in a `try...catch`
- * block. Any thrown exceptions are caught and processed by `handleError()`, which logs the
- * error locally and remotely in Plugin API.
+ * It runAction()`, wrapping the execution in a `try...catch` block. Any thrown exceptions
+ * are caught and processed by `handleError()`, which logs the error locally and remotely
+ * in Plugin API.
  *
  * Controllers intended for web or AJAX endpoints wtihin the plugin should extend this to
  * inherit the logging behavior.
@@ -33,35 +33,6 @@ use yii\base\Action;
  */
 class PluginController extends Controller
 {
-    /**
-     * Catches any errors that occur before an action runs.
-     *
-     * This is executed by Yii before any controller action. It wraps the parent method
-     * in a `try...catch` to handle exceptions that occur during pre-action events and checks.
-     * If an error is caught, it is logged locally and remotely in Plugin API and the action
-     * is prevented from running.
-     *
-     * @param Action $action The action to be executed.
-     * @return bool Whether the action should continue to run. Returns `false` on error.
-     */
-
-    public function beforeAction($action): bool
-    {
-        try {
-            return parent::beforeAction($action);
-        } catch (\Throwable $e) {
-            $proofException = new \RuntimeException(
-                'PROOF_BEFORE_ACTION_CAUGHT: ' . $e->getMessage(),
-                $e->getCode(),
-                $e
-            );
-            $this->handleError($proofException, $action->id);
-
-            // prevents the action from running.
-            return false;
-        }
-    }
-
     /**
      * Catches any errors that occur during an action's execution.
      *

--- a/src/controllers/PluginController.php
+++ b/src/controllers/PluginController.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * @link      https://github.com/lilt
+ * @copyright Copyright (c) 2025 Lilt Devs
+ */
+
+declare(strict_types=1);
+
 namespace lilthq\craftliltplugin\controllers;
 
 use Craft;
@@ -7,15 +14,37 @@ use craft\web\Controller;
 use lilthq\craftliltplugin\Craftliltplugin;
 use yii\base\Action;
 
+/**
+ * Plugin Controller
+ *
+ * A base controller that extends craft\web\Controller. This provides centralized error
+ * handling for all controllers that extend it, reporting any beforeAction and runAction
+ * errors that occur back to the Plugin API.
+ *
+ * It overrides the `beforeAction()` and `runAction()`, wrapping exectution in a `try...catch`
+ * block. Any thrown exceptions are caught and processed by `handleError()`, which logs the
+ * error locally and remotely in Plugin API.
+ *
+ * Controllers intended for web or AJAX endpoints wtihin the plugin should extend this to
+ * inherit the logging behavior.
+ *
+ * @package lilthq\craftliltplugin\controllers
+ * @since 1.0.0
+ */
 class PluginController extends Controller
 {
     /**
-     * Catch any errors that occur before an action runs within a controller. If an error
-     * is caught, a log will be sent to Plugin API's POST /logs endpoint.
+     * Catches any errors that occur before an action runs.
      *
-     * @param Action $action the action to be executed.
-     * @return bool whether the action should continue to run or not.
+     * This is executed by Yii before any controller action. It wraps the parent method
+     * in a `try...catch` to handle exceptions that occur during pre-action events and checks.
+     * If an error is caught, it is logged locally and remotely in Plugin API and the action
+     * is prevented from running.
+     *
+     * @param Action $action The action to be executed.
+     * @return bool Whether the action should continue to run. Returns `false` on error.
      */
+
     public function beforeAction($action): bool
     {
         try {
@@ -23,17 +52,22 @@ class PluginController extends Controller
         } catch (\Throwable $e) {
             $this->handleError($e, $action->id);
 
+            // prevents the action from running.
             return false;
         }
     }
 
     /**
-     * Catch any errors that occur during an action being executed within a controller.
-     * If an error occurs, a log will be sent to Plugin API's POST /logs endpoint.
+     * Catches any errors that occur during an action's execution.
      *
-     * @param string $id the ID of the action being executed.
-     * @param array $params the parameters passed to the action.
-     * @return mixed the result of the action.
+     * This method is responsible for running the specified action. It wraps the parent
+     * method in a `try...catch` to handle exceptions that occur within the action itself.
+     * If an error is caught, it is logged locally and remotely in Plugin API and a standardized
+     * error response is returned.
+     *
+     * @param string $id The ID of the action to be executed.
+     * @param array $params The parameters to be passed to the action.
+     * @return mixed The result of the action on success, or a JSON Response on failure.
      */
     public function runAction($id, $params = []): mixed
     {
@@ -50,13 +84,17 @@ class PluginController extends Controller
     }
 
     /**
-     * Handles errors that occur within beforeAction or runAction. This will trigger a
-     * Craft::error for server logs as well as send the log to Plugin API's POST /logs
-     * endpoint.
+     * Handles and logs errors thrown caught from `beforeAction` and `runAction`.
      *
-     * @param \Throwable $e the thrown exception that occurred.
-     * @param string $event the ID of the event.
-     * @param array $params the parameters passed to the action.
+     * This method implements both local logging via `Craft::error` and remote logging
+     * to the Plugin API's POST /logs endpoint.
+     *
+     * If the Plugin API call fails, the failure will also be logged locally to ensure
+     * no error context is lost.
+     *
+     * @param \Throwable $e The thrown exception that occurred.
+     * @param string $event The ID of the action/event where the error occurred.
+     * @param array $params The parameters that were passed to the action.
      */
     private function handleError(\Throwable $e, string $event, array $params = []): void
     {
@@ -83,6 +121,14 @@ class PluginController extends Controller
                 $e->getMessage(),
                 $metadata,
             );
-        } catch (\Throwable $ignored) {}
+        } catch (\Throwable $err) {
+            // If the remote API logging fails, log that failure locally.
+            Craft::error('Controller error: ' . json_encode([
+                'event' => $event,
+                'message' => $err->getMessage(),
+                'route' => $this->id . '/' . $event,
+                'method' => $request->getMethod(),
+            ]), __METHOD__);
+        }
     }
 }

--- a/src/controllers/PostConfigurationController.php
+++ b/src/controllers/PostConfigurationController.php
@@ -14,14 +14,15 @@ use craft\helpers\UrlHelper;
 use Exception;
 use GuzzleHttp\Client;
 use LiltConnectorSDK\Api\SettingsApi;
+use LiltConnectorSDK\Configuration as LiltConnectorConfiguration;
+use LiltConnectorSDK\Model\SettingsResponse1 as SettingsRequest;
 use lilthq\craftliltplugin\controllers\job\AbstractJobController;
 use lilthq\craftliltplugin\Craftliltplugin;
-use LiltConnectorSDK\Configuration as LiltConnectorConfiguration;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\services\repositories\SettingsRepository;
 use lilthq\craftliltplugin\utilities\Configuration;
 use Throwable;
 use yii\web\Response;
-use LiltConnectorSDK\Model\SettingsResponse1 as SettingsRequest;
 
 class PostConfigurationController extends AbstractJobController
 {
@@ -57,7 +58,7 @@ class PostConfigurationController extends AbstractJobController
                 $connectorApiKey
             );
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => "Can't connect to Lilt",
                 'exception_message' => $ex->getMessage(),
                 'exception_trace' => $ex->getTrace(),
@@ -136,7 +137,7 @@ class PostConfigurationController extends AbstractJobController
                 $settingsRequest
             );
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => "Can't connect to Lilt",
                 'exception_message' => $ex->getMessage(),
                 'exception_trace' => $ex->getTrace(),

--- a/src/controllers/job/AbstractJobController.php
+++ b/src/controllers/job/AbstractJobController.php
@@ -10,9 +10,9 @@ declare(strict_types=1);
 namespace lilthq\craftliltplugin\controllers\job;
 
 use Craft;
-use craft\web\Controller;
 use Exception;
 use lilthq\craftliltplugin\assets\JobFormAsset;
+use lilthq\craftliltplugin\controllers\PluginController;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\parameters\CraftliltpluginParameters;
@@ -21,7 +21,7 @@ use yii\base\InvalidConfigException;
 use yii\web\IdentityInterface;
 use yii\web\Response;
 
-class AbstractJobController extends Controller
+class AbstractJobController extends PluginController
 {
     /**
      * @throws InvalidConfigException

--- a/src/controllers/job/AbstractJobController.php
+++ b/src/controllers/job/AbstractJobController.php
@@ -15,6 +15,7 @@ use lilthq\craftliltplugin\assets\JobFormAsset;
 use lilthq\craftliltplugin\controllers\PluginController;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\parameters\CraftliltpluginParameters;
 use RuntimeException;
 use yii\base\InvalidConfigException;
@@ -85,7 +86,7 @@ class AbstractJobController extends PluginController
                 );
                 $translationWorkflow = strtolower($settingsResult->getLiltTranslationWorkflow());
             } catch (Exception $ex) {
-                Craft::error([
+                LiltLogger::error([
                     'message' => "Can't fetch translation workflow",
                     'exception_message' => $ex->getMessage(),
                     'exception_trace' => $ex->getTrace(),

--- a/src/controllers/job/GetSendToLiltController.php
+++ b/src/controllers/job/GetSendToLiltController.php
@@ -13,8 +13,8 @@ use Craft;
 use craft\errors\ElementNotFoundException;
 use craft\errors\MissingComponentException;
 use craft\helpers\Queue;
-use craft\web\Controller;
 use LiltConnectorSDK\ApiException;
+use lilthq\craftliltplugin\controllers\PluginController;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\modules\SendJobToConnector;
@@ -25,7 +25,7 @@ use yii\base\Exception;
 use yii\db\StaleObjectException;
 use yii\web\Response;
 
-class GetSendToLiltController extends Controller
+class GetSendToLiltController extends PluginController
 {
     protected array|int|bool $allowAnonymous = false;
 

--- a/src/controllers/job/GetSyncFromLiltController.php
+++ b/src/controllers/job/GetSyncFromLiltController.php
@@ -10,12 +10,12 @@ declare(strict_types=1);
 namespace lilthq\craftliltplugin\controllers\job;
 
 use Craft;
-use craft\web\Controller;
+use lilthq\craftliltplugin\controllers\PluginController;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use yii\web\Response;
 
-class GetSyncFromLiltController extends Controller
+class GetSyncFromLiltController extends PluginController
 {
     protected array|int|bool $allowAnonymous = false;
 

--- a/src/controllers/job/PostJobRetryController.php
+++ b/src/controllers/job/PostJobRetryController.php
@@ -6,15 +6,15 @@ namespace lilthq\craftliltplugin\controllers\job;
 
 use Craft;
 use craft\errors\ElementNotFoundException;
-use craft\web\Controller;
 use LiltConnectorSDK\ApiException;
+use lilthq\craftliltplugin\controllers\PluginController;
 use lilthq\craftliltplugin\Craftliltplugin;
 use Throwable;
 use yii\base\Exception;
 use yii\db\StaleObjectException;
 use yii\web\Response;
 
-class PostJobRetryController extends Controller
+class PostJobRetryController extends PluginController
 {
     /**
      * @throws ElementNotFoundException

--- a/src/controllers/job/PostSyncController.php
+++ b/src/controllers/job/PostSyncController.php
@@ -11,7 +11,7 @@ namespace lilthq\craftliltplugin\controllers\job;
 
 use Craft;
 use craft\helpers\Queue;
-use craft\web\Controller;
+use lilthq\craftliltplugin\controllers\PluginController;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\elements\Translation;
@@ -21,7 +21,7 @@ use lilthq\craftliltplugin\records\TranslationNotificationsRecord;
 use lilthq\craftliltplugin\records\TranslationRecord;
 use yii\web\Response;
 
-class PostSyncController extends Controller
+class PostSyncController extends PluginController
 {
     public function actionInvoke(): Response
     {

--- a/src/modules/AbstractRetryJob.php
+++ b/src/modules/AbstractRetryJob.php
@@ -12,8 +12,8 @@ namespace lilthq\craftliltplugin\modules;
 use Craft;
 use craft\queue\BaseJob;
 use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\JobRecord;
-use RuntimeException;
 
 abstract class AbstractRetryJob extends BaseJob
 {
@@ -51,7 +51,7 @@ abstract class AbstractRetryJob extends BaseJob
         ) {
             $msg = sprintf('Job %s is already processing %s', __CLASS__, $this->getMutexKey());
 
-            Craft::error($msg);
+            LiltLogger::error($msg);
 
             return null;
         }
@@ -66,7 +66,7 @@ abstract class AbstractRetryJob extends BaseJob
         $jobRecord = JobRecord::findOne(['id' => $jobId]);
 
         if (!$jobRecord) {
-            Craft::error(sprintf("Can't find JobRecord for job id: %d", $jobId));
+            LiltLogger::error(sprintf("Can't find JobRecord for job id: %d", $jobId));
 
             return null;
         }

--- a/src/modules/FetchJobStatusFromConnector.php
+++ b/src/modules/FetchJobStatusFromConnector.php
@@ -17,6 +17,7 @@ use LiltConnectorSDK\Model\JobResponse;
 use LiltConnectorSDK\Model\TranslationResponse;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\JobRecord;
 use lilthq\craftliltplugin\records\TranslationRecord;
 use lilthq\craftliltplugin\services\repositories\SettingsRepository;
@@ -65,7 +66,7 @@ class FetchJobStatusFromConnector extends AbstractRetryJob
         $mutex = Craft::$app->getMutex();
         $mutexKey = $this->getMutexKey();
         if (!$mutex->acquire($mutexKey)) {
-            Craft::error(sprintf('Job %s is already processing job %d', __CLASS__, $this->jobId));
+            LiltLogger::error(sprintf('Job %s is already processing job %d', __CLASS__, $this->jobId));
 
             $this->markAsDone($queue);
             return;
@@ -119,7 +120,7 @@ class FetchJobStatusFromConnector extends AbstractRetryJob
                 ['jobId' => $jobRecord->id]
             );
 
-            Craft::error([
+            LiltLogger::error([
                 "message" => sprintf(
                     'Set job %d and translations to status failed due to failed/cancel status from lilt',
                     $jobRecord->id
@@ -189,7 +190,7 @@ class FetchJobStatusFromConnector extends AbstractRetryJob
                 $jobRecord->status = Job::STATUS_FAILED;
                 $jobRecord->save();
 
-                Craft::error([
+                LiltLogger::error([
                     "message" => sprintf(
                         'Set job %d and translations to status failed due to failed status for translation from lilt',
                         $jobRecord->id

--- a/src/modules/FetchTranslationFromConnector.php
+++ b/src/modules/FetchTranslationFromConnector.php
@@ -18,6 +18,7 @@ use LiltConnectorSDK\ApiException;
 use LiltConnectorSDK\Model\TranslationResponse;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\parameters\CraftliltpluginParameters;
 use lilthq\craftliltplugin\records\TranslationRecord;
 use Throwable;
@@ -52,7 +53,7 @@ class FetchTranslationFromConnector extends AbstractRetryJob
     {
         $job = Job::findOne(['id' => $this->jobId]);
         if (!$job) {
-            Craft::error(sprintf('[%s] Job not found: %d', __CLASS__, $this->jobId));
+            LiltLogger::error(sprintf('[%s] Job not found: %d', __CLASS__, $this->jobId));
 
             $this->markAsDone($queue);
             return;
@@ -60,7 +61,7 @@ class FetchTranslationFromConnector extends AbstractRetryJob
 
         $translationRecord = TranslationRecord::findOne(['id' => $this->translationId]);
         if (!$translationRecord) {
-            Craft::error(sprintf('[%s] Translation not found: %d', __CLASS__, $this->translationId));
+            LiltLogger::error(sprintf('[%s] Translation not found: %d', __CLASS__, $this->translationId));
 
             $this->markAsDone($queue);
             return;
@@ -69,7 +70,7 @@ class FetchTranslationFromConnector extends AbstractRetryJob
         $mutex = Craft::$app->getMutex();
         $mutexKey = __CLASS__ . '_' . __FUNCTION__ . '_' . $this->jobId . '_' . $this->translationId;
         if (!$mutex->acquire($mutexKey)) {
-            Craft::error(sprintf('Job %s is already processing job %d', __CLASS__, $this->jobId));
+            LiltLogger::error(sprintf('Job %s is already processing job %d', __CLASS__, $this->jobId));
 
             $this->markAsDone($queue);
             return;
@@ -82,7 +83,7 @@ class FetchTranslationFromConnector extends AbstractRetryJob
 
         if (empty($translationRecord->connectorTranslationId)) {
             //TODO: we can push message to fix connector id
-            Craft::error(
+            LiltLogger::error(
                 sprintf(
                     "Connector translation id is empty for translation:"
                     . "%d source site: %d (%s) target site: %d (%s) lilt job: %d element: %d",
@@ -127,7 +128,7 @@ class FetchTranslationFromConnector extends AbstractRetryJob
                 ]
             );
 
-            Craft::error([
+            LiltLogger::error([
                 "message" => sprintf(
                     'Set translation %d to status failed, got status failed from lilt platform',
                     $translationRecord->id
@@ -169,7 +170,7 @@ class FetchTranslationFromConnector extends AbstractRetryJob
                 $job
             );
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => "Can't fetch translation due to error",
                 'exception_message' => $ex->getMessage(),
                 'exception_trace' => $ex->getTrace(),

--- a/src/modules/ManualJobSync.php
+++ b/src/modules/ManualJobSync.php
@@ -12,13 +12,14 @@ namespace lilthq\craftliltplugin\modules;
 use Craft;
 use craft\db\Table;
 use craft\helpers\Db;
+use craft\helpers\Queue as CraftHelpersQueue;
 use craft\queue\BaseJob;
 use craft\queue\Queue;
-use craft\helpers\Queue as CraftHelpersQueue;
 use Exception;
 use LiltConnectorSDK\Model\JobResponse;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\JobRecord;
 use lilthq\craftliltplugin\records\TranslationRecord;
 
@@ -49,7 +50,7 @@ class ManualJobSync extends BaseJob
         $mutexKey = __CLASS__ . '_' . __FUNCTION__ . '_' . join('_', $this->jobIds);
 
         if (!$mutex->acquire($mutexKey)) {
-            Craft::error('Lilt queue manager is already running');
+            LiltLogger::error('Lilt queue manager is already running');
 
             $this->setProgress(
                 $queue,
@@ -122,7 +123,7 @@ class ManualJobSync extends BaseJob
                         'id' => $jobInfo['id'],
                     ], [], false);
                 } catch (Exception $ex) {
-                    Craft::error(
+                    LiltLogger::error(
                         sprintf(
                             "Can't update delay for job: %d. Due to issue: %s",
                             $jobInfo['id'],
@@ -153,7 +154,7 @@ class ManualJobSync extends BaseJob
                     $queue->retry((string)$jobInfo['id']);
                     $jobsInProgress[$queueJob->jobId] = $queueJob;
                 } catch (Exception $ex) {
-                    Craft::error(
+                    LiltLogger::error(
                         sprintf(
                             "Can't retry job: %d. Due to issue: %s",
                             $jobInfo['id'],

--- a/src/modules/QueueManager.php
+++ b/src/modules/QueueManager.php
@@ -10,10 +10,11 @@ declare(strict_types=1);
 namespace lilthq\craftliltplugin\modules;
 
 use Craft;
-use craft\queue\BaseJob;
 use craft\helpers\Queue as CraftHelpersQueue;
+use craft\queue\BaseJob;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\parameters\CraftliltpluginParameters;
 use lilthq\craftliltplugin\records\JobRecord;
 use lilthq\craftliltplugin\services\repositories\SettingsRepository;
@@ -39,7 +40,7 @@ class QueueManager extends BaseJob
         $mutex = Craft::$app->getMutex();
         $mutexKey = self::getMutexKey();
         if (!$mutex->acquire($mutexKey)) {
-            Craft::warning('Lilt queue manager is already running');
+            LiltLogger::warning('Lilt queue manager is already running');
 
             $this->setProgress(
                 $queue,
@@ -62,7 +63,7 @@ class QueueManager extends BaseJob
         ]);
 
         if (count($jobRecords) === 0) {
-            Craft::info([
+            LiltLogger::info([
                 'message' => 'No jobs found in progress ',
                 'queue' => __FILE__,
             ]);
@@ -90,7 +91,7 @@ class QueueManager extends BaseJob
             0
         );
 
-        Craft::info([
+        LiltLogger::info([
             'message' => 'Push jobs in progress for manual sync',
             'jobIds' => $jobIds,
             'queue' => __FILE__,

--- a/src/modules/SendJobToConnector.php
+++ b/src/modules/SendJobToConnector.php
@@ -15,6 +15,7 @@ use craft\queue\BaseJob;
 use LiltConnectorSDK\ApiException;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\JobRecord;
 use Throwable;
 
@@ -47,7 +48,7 @@ class SendJobToConnector extends AbstractRetryJob
         $jobRecord = JobRecord::findOne(['id' => $jobId]);
 
         if (!$jobRecord) {
-            Craft::error(sprintf("Can't find JobRecord for job id: %d", $jobId));
+            LiltLogger::error(sprintf("Can't find JobRecord for job id: %d", $jobId));
 
             return;
         }
@@ -56,7 +57,7 @@ class SendJobToConnector extends AbstractRetryJob
         $mutexKey = __CLASS__ . '_' . __FUNCTION__ . '_' . $this->jobId;
 
         if (!$mutex->acquire($mutexKey)) {
-            Craft::error(sprintf('Job %s is already processing job %d', __CLASS__, $this->jobId));
+            LiltLogger::error(sprintf('Job %s is already processing job %d', __CLASS__, $this->jobId));
 
             return;
         }

--- a/src/modules/SendTranslationToConnector.php
+++ b/src/modules/SendTranslationToConnector.php
@@ -18,6 +18,7 @@ use LiltConnectorSDK\Model\JobResponse;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\exceptions\JobNotStartedException;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\models\TranslationModel;
 use lilthq\craftliltplugin\records\TranslationRecord;
 use lilthq\craftliltplugin\services\handlers\commands\SendTranslationCommand;
@@ -67,7 +68,7 @@ class SendTranslationToConnector extends AbstractRetryJob
         }
 
         if (!$command->getJob()->isVerifiedFlow() && !$command->getJob()->isInstantFlow()) {
-            Craft::error(
+            LiltLogger::error(
                 sprintf(
                     "Job can't be proceed, incorrect flow %s: %d",
                     $command->getJob()->translationWorkflow,
@@ -79,7 +80,7 @@ class SendTranslationToConnector extends AbstractRetryJob
         }
 
         if (empty($command->getJob()->liltJobId)) {
-            Craft::error(
+            LiltLogger::error(
                 sprintf(
                     "Job can't be proceed, empty lilt id [%s]: %d",
                     $command->getJob()->translationWorkflow,
@@ -175,7 +176,7 @@ class SendTranslationToConnector extends AbstractRetryJob
                     $command->getJob()->liltJobId
                 );
                 if (!$result) {
-                    Craft::error(
+                    LiltLogger::error(
                         sprintf(
                             'Can\'t start job %d, lilt id: %d',
                             $command->getJob()->id,

--- a/src/services/ServiceInitializer.php
+++ b/src/services/ServiceInitializer.php
@@ -321,6 +321,15 @@ class ServiceInitializer
             }
         ]);
 
+        $pluginInstance->setComponents([
+            'logsApi' => function () use ($pluginInstance) {
+                return new LogsApi(
+                    new Client(),
+                    $pluginInstance->connectorConfiguration
+                );
+            }
+        ]);
+
         $pluginInstance->listenerRegister->register();
         $pluginInstance->loadI18NHandler->__invoke();
     }

--- a/src/services/appliers/field/AbstractContentApplier.php
+++ b/src/services/appliers/field/AbstractContentApplier.php
@@ -9,6 +9,7 @@ use Craft;
 use craft\base\FieldInterface;
 use craft\elements\MatrixBlock;
 use craft\errors\InvalidFieldException;
+use lilthq\craftliltplugin\LiltLogger;
 use verbb\supertable\elements\SuperTableBlockElement;
 
 abstract class AbstractContentApplier
@@ -71,7 +72,7 @@ abstract class AbstractContentApplier
     protected function getOriginalFieldSerializedValue(ApplyContentCommand $command)
     {
         if (empty($command->getField()->handle)) {
-            Craft::warning([
+            LiltLogger::warning([
                 'message' => 'Handle for field is empty, please check CraftCMS configuration',
                 'field' => $command->getField()->toArray()
             ]);
@@ -84,7 +85,7 @@ abstract class AbstractContentApplier
         );
 
         if (empty($fieldValue)) {
-            Craft::warning([
+            LiltLogger::warning([
                 'message' => 'Field value is empty, please configure it for proper translation',
                 'field' => $command->getField()->toArray(),
                 'fieldValue' => $fieldValue,

--- a/src/services/handlers/CreateDraftHandler.php
+++ b/src/services/handlers/CreateDraftHandler.php
@@ -17,6 +17,7 @@ use craft\errors\InvalidFieldException;
 use craft\helpers\Db;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\datetime\DateTime;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\parameters\CraftliltpluginParameters;
 use lilthq\craftliltplugin\records\SettingRecord;
 use lilthq\craftliltplugin\services\handlers\commands\CreateDraftCommand;
@@ -84,7 +85,7 @@ class CreateDraftHandler
 
         $result = Craft::$app->elements->saveElement($draft, true, false, false);
         if (!$result) {
-            Craft::error(
+            LiltLogger::error(
                 sprintf(
                     "Can't save freshly created draft %d for site %s",
                     $draft->id,
@@ -115,7 +116,7 @@ class CreateDraftHandler
 
         $result = Craft::$app->elements->saveElement($draft, true, false, false);
         if (!$result) {
-            Craft::error(
+            LiltLogger::error(
                 sprintf(
                     "Can't save freshly createdd draft %d for site %s",
                     $draft->id,

--- a/src/services/handlers/EditJobHandler.php
+++ b/src/services/handlers/EditJobHandler.php
@@ -13,6 +13,7 @@ use Craft;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\exceptions\JobNotFoundException;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\JobRecord;
 use lilthq\craftliltplugin\services\handlers\commands\EditJobCommand;
 use lilthq\craftliltplugin\services\repositories\JobRepository;
@@ -33,7 +34,7 @@ class EditJobHandler
         $jobRecord = JobRecord::findOne(['id' => $command->getJobId()]);
 
         if (!$job || !$jobRecord) {
-            Craft::error(
+            LiltLogger::error(
                 sprintf('Job with id %d not found', $command->getJobId())
             );
 

--- a/src/services/handlers/PublishDraftHandler.php
+++ b/src/services/handlers/PublishDraftHandler.php
@@ -11,8 +11,8 @@ namespace lilthq\craftliltplugin\services\handlers;
 
 use Craft;
 use craft\base\ElementInterface;
-use craft\errors\InvalidElementException;
 use craft\services\Drafts as DraftRepository;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\SettingRecord;
 use Throwable;
 use yii\base\Exception;
@@ -65,7 +65,7 @@ class PublishDraftHandler
         }
 
         if (!Craft::$app->getElements()->saveElement($draft)) {
-            Craft::warning([
+            LiltLogger::warning([
                 'message' => "Could not propagate draft {$draft->id} for entry {$draft->canonicalId}.",
             ]);
         }

--- a/src/services/handlers/ResolveTranslationsConnectorIds.php
+++ b/src/services/handlers/ResolveTranslationsConnectorIds.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 
 namespace lilthq\craftliltplugin\services\handlers;
 
-use Craft;
 use LiltConnectorSDK\ApiException;
 use LiltConnectorSDK\Model\TranslationResponse;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\exceptions\WrongTranslationFilenameException;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\TranslationRecord;
 use RuntimeException;
 
@@ -45,7 +45,7 @@ class ResolveTranslationsConnectorIds
                     ->connectorTranslationRepository
                     ->getElementIdFromTranslationResponse($translationResponse);
             } catch (WrongTranslationFilenameException $ex) {
-                Craft::error(sprintf("Can't get element id from file: %s", $translationResponse->getName()));
+                LiltLogger::error(sprintf("Can't get element id from file: %s", $translationResponse->getName()));
                 continue;
             }
 
@@ -108,7 +108,7 @@ class ResolveTranslationsConnectorIds
                     ->connectorTranslationRepository
                     ->getElementIdFromTranslationResponse($translationResponse);
             } catch (WrongTranslationFilenameException $ex) {
-                Craft::error(sprintf("Can't get element id from file: %s", $translationResponse->getName()));
+                LiltLogger::error(sprintf("Can't get element id from file: %s", $translationResponse->getName()));
                 continue;
             }
 

--- a/src/services/handlers/SendJobToLiltConnectorHandler.php
+++ b/src/services/handlers/SendJobToLiltConnectorHandler.php
@@ -16,6 +16,7 @@ use LiltConnectorSDK\ApiException;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\exceptions\JobNotStartedException;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\modules\FetchJobStatusFromConnector;
 use lilthq\craftliltplugin\modules\SendTranslationToConnector;
 use lilthq\craftliltplugin\records\JobRecord;
@@ -116,7 +117,7 @@ class SendJobToLiltConnectorHandler
             $element = Craft::$app->elements->getElementById($versionId, null, $job->sourceSiteId);
 
             if (!$element) {
-                Craft::error(
+                LiltLogger::error(
                     sprintf("Can't find element: %d for job: %d", $versionId, $job->id)
                 );
 
@@ -128,7 +129,7 @@ class SendJobToLiltConnectorHandler
 
                 if (empty($translation) || empty($translation->id)) {
                     // let's create translation, looks like it is lost
-                    Craft::warning(
+                    LiltLogger::warning(
                         [
                             'message' => 'Force create translation, it was not created before!',
                             'versionId' => $versionId,
@@ -197,7 +198,7 @@ class SendJobToLiltConnectorHandler
 
         $result = $this->connectorJobRepository->start($jobLilt->getId());
         if (!$result) {
-            Craft::error(
+            LiltLogger::error(
                 sprintf(
                     'Can\'t start job %d, lilt id: %d',
                     $jobLilt->id,

--- a/src/services/handlers/SendTranslationToLiltConnectorHandler.php
+++ b/src/services/handlers/SendTranslationToLiltConnectorHandler.php
@@ -12,11 +12,10 @@ namespace lilthq\craftliltplugin\services\handlers;
 use Craft;
 use craft\base\ElementInterface;
 use craft\errors\ElementNotFoundException;
-use craft\helpers\Queue;
 use DateTimeInterface;
 use LiltConnectorSDK\ApiException;
 use lilthq\craftliltplugin\elements\Job;
-use lilthq\craftliltplugin\modules\FetchJobStatusFromConnector;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\JobRecord;
 use lilthq\craftliltplugin\records\TranslationRecord;
 use lilthq\craftliltplugin\services\handlers\commands\CreateDraftCommand;
@@ -24,7 +23,6 @@ use lilthq\craftliltplugin\services\handlers\commands\SendTranslationCommand;
 use lilthq\craftliltplugin\services\mappers\LanguageMapper;
 use lilthq\craftliltplugin\services\providers\ElementTranslatableContentProvider;
 use lilthq\craftliltplugin\services\repositories\external\ConnectorFileRepository;
-use lilthq\craftliltplugin\services\repositories\external\ConnectorJobRepository;
 use lilthq\craftliltplugin\services\repositories\JobLogsRepository;
 use lilthq\craftliltplugin\services\repositories\TranslationRepository;
 use Throwable;
@@ -233,7 +231,7 @@ class SendTranslationToLiltConnectorHandler
                 return $draft;
             }
 
-            Craft::warning([
+            LiltLogger::warning([
                 'message' => 'Draft was not found for job, fallback to create bew one',
                 'jobId' => $job->id,
                 'translationId' => $translation->id,

--- a/src/services/handlers/SyncJobFromLiltConnectorHandler.php
+++ b/src/services/handlers/SyncJobFromLiltConnectorHandler.php
@@ -13,6 +13,7 @@ use LiltConnectorSDK\Model\TranslationResponse;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\datetime\DateTime;
 use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\JobRecord;
 use lilthq\craftliltplugin\records\TranslationNotificationsRecord;
 use lilthq\craftliltplugin\records\TranslationRecord;
@@ -66,7 +67,7 @@ class SyncJobFromLiltConnectorHandler
                 try {
                     $this->processTranslation($translationDto, $job);
                 } catch (Exception $ex) {
-                    Craft::error([
+                    LiltLogger::error([
                         'message' => "Can't process translation due to error",
                         'exception_message' => $ex->getMessage(),
                         'exception_trace' => $ex->getTrace(),
@@ -129,7 +130,7 @@ class SyncJobFromLiltConnectorHandler
             ]);
 
             if (!$translationRecord) {
-                Craft::error(
+                LiltLogger::error(
                     sprintf(
                         'Translation record of jobId: %d not found, looks like job was removed.'
                         . ' Translation fetching aborted.',

--- a/src/services/handlers/TranslationFailedHandler.php
+++ b/src/services/handlers/TranslationFailedHandler.php
@@ -11,6 +11,7 @@ use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\datetime\DateTime;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\exceptions\WrongTranslationFilenameException;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\TranslationRecord;
 
 class TranslationFailedHandler
@@ -40,7 +41,7 @@ class TranslationFailedHandler
         );
 
         if (!$element) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => "Can't find element!",
                 'target_language' => $translationTargetLanguage,
                 'element_id' => $elementId,
@@ -58,7 +59,7 @@ class TranslationFailedHandler
         $parentElementId = $element->getCanonicalId() ?? $elementId;
 
         if (!isset($unprocessedTranslations[$parentElementId][$targetSiteId])) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => "Can't find translation!",
                 'target_language' => $translationTargetLanguage,
                 'parent_elementId' => $parentElementId,

--- a/src/services/handlers/UpdateJobStatusHandler.php
+++ b/src/services/handlers/UpdateJobStatusHandler.php
@@ -13,6 +13,7 @@ use Craft;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\elements\Translation;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\models\TranslationModel;
 use lilthq\craftliltplugin\records\JobRecord;
 use lilthq\craftliltplugin\records\TranslationRecord;
@@ -51,7 +52,7 @@ class UpdateJobStatusHandler
 
             $jobRecord->save();
 
-            Craft::error([
+            LiltLogger::error([
                 "message" =>  sprintf(
                     'Set job %d and translations to status failed',
                     $jobRecord->id
@@ -65,7 +66,7 @@ class UpdateJobStatusHandler
             $jobRecord->status = Job::STATUS_NEEDS_ATTENTION;
             $jobRecord->save();
 
-            Craft::warning([
+            LiltLogger::warning([
                 "message" =>  sprintf(
                     'Set job %d and translations to status needs attention',
                     $jobRecord->id

--- a/src/services/listeners/AfterErrorListener.php
+++ b/src/services/listeners/AfterErrorListener.php
@@ -15,6 +15,7 @@ use LiltConnectorSDK\ApiException;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\elements\Job;
 use lilthq\craftliltplugin\elements\Translation;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\modules\AbstractRetryJob;
 use lilthq\craftliltplugin\modules\FetchJobStatusFromConnector;
 use lilthq\craftliltplugin\modules\FetchTranslationFromConnector;
@@ -75,7 +76,7 @@ class AfterErrorListener implements ListenerInterface
 
         $jobRecord = JobRecord::findOne(['id' => $queueJob->jobId]);
 
-        Craft::error([
+        LiltLogger::error([
             "message" => sprintf(
                 'Job %s failed due to: %s',
                 get_class($queueJob),
@@ -89,7 +90,7 @@ class AfterErrorListener implements ListenerInterface
         ]);
 
         if (!$queueJob->canRetry()) {
-            Craft::warning([
+            LiltLogger::warning([
                 "message" => sprintf(
                     'Job %s can\'t be retried',
                     $event->id
@@ -118,7 +119,7 @@ class AfterErrorListener implements ListenerInterface
                 (string)$event->id
             );
 
-            Craft::error([
+            LiltLogger::error([
                 "message" => sprintf(
                     '[%s] Mark lilt job %d (%d) as failed due to: %s',
                     get_class($queueJob),
@@ -164,7 +165,7 @@ class AfterErrorListener implements ListenerInterface
             (string)$event->id
         );
 
-        Craft::info([
+        LiltLogger::info([
             "message" => sprintf(
                 'Released job %s',
                 $event->id
@@ -196,7 +197,7 @@ class AfterErrorListener implements ListenerInterface
                 $retryJob::getDelay()
             );
 
-            Craft::info([
+            LiltLogger::info([
                 "message" => 'Retried job due to infrastructure error',
                 "queueJob" => $retryJob,
                 "isApiError" => $isApiError,
@@ -216,7 +217,7 @@ class AfterErrorListener implements ListenerInterface
             $retryJob::getDelay()
         );
 
-        Craft::info([
+        LiltLogger::info([
             "message" => sprintf(
                 'Retried job, attempt %d',
                 $queueJob->attempt

--- a/src/services/providers/ConnectorConfigurationProvider.php
+++ b/src/services/providers/ConnectorConfigurationProvider.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace lilthq\craftliltplugin\services\providers;
 
-use Craft;
 use Exception;
 use LiltConnectorSDK\Configuration;
 use lilthq\craftliltplugin\Craftliltplugin;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\SettingRecord;
 
 class ConnectorConfigurationProvider
@@ -28,7 +28,7 @@ class ConnectorConfigurationProvider
         try {
             $connectorApiUrlRecord = SettingRecord::findOne(['name' => 'connector_api_url']);
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => "Can't find connector_api_url record!",
                 'exception_message' => $ex->getMessage(),
                 'exception_trace' => $ex->getTrace(),

--- a/src/services/providers/ElementTranslatableContentProvider.php
+++ b/src/services/providers/ElementTranslatableContentProvider.php
@@ -19,6 +19,7 @@ use craft\fields\MultiSelect;
 use craft\fields\RadioButtons;
 use craft\fields\Table;
 use lilthq\craftliltplugin\Craftliltplugin;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\services\providers\command\ProvideContentCommand;
 
 class ElementTranslatableContentProvider
@@ -48,7 +49,7 @@ class ElementTranslatableContentProvider
             $fieldData = Craft::$app->fields->getFieldById((int) $field->id);
 
             if ($fieldData === null) {
-                Craft::error(
+                LiltLogger::error(
                     sprintf("Can't get field data for field %d", $field->id)
                 );
 

--- a/src/services/repositories/external/AbstractConnectorExternalRepository.php
+++ b/src/services/repositories/external/AbstractConnectorExternalRepository.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace lilthq\craftliltplugin\services\repositories\external;
 
-use Craft;
 use Exception;
 use LiltConnectorSDK\Api\JobsApi;
 use LiltConnectorSDK\Api\TranslationsApi;
 use LiltConnectorSDK\ApiException;
+use lilthq\craftliltplugin\LiltLogger;
 
 class AbstractConnectorExternalRepository
 {
@@ -28,7 +28,7 @@ class AbstractConnectorExternalRepository
     protected function handleException(Exception $ex): void
     {
         if ($ex instanceof ApiException) {
-            Craft::warning([
+            LiltLogger::warning([
                 'message' => sprintf(
                     'Communication exception when calling JobsApi->servicesApiJobsAddFile: %s',
                     $ex->getMessage()

--- a/src/services/repositories/external/ConnectorFileRepository.php
+++ b/src/services/repositories/external/ConnectorFileRepository.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace lilthq\craftliltplugin\services\repositories\external;
 
-use Craft;
 use DateTimeInterface;
 use Exception;
 use LiltConnectorSDK\ApiException;
+use lilthq\craftliltplugin\LiltLogger;
 
 class ConnectorFileRepository extends AbstractConnectorExternalRepository implements ConnectorFileRepositoryInterface
 {
@@ -40,7 +40,7 @@ class ConnectorFileRepository extends AbstractConnectorExternalRepository implem
             $this->handleException($ex);
             return false;
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => sprintf(
                     'Exception when calling JobsApi->servicesApiJobsAddFile: %s',
                     $ex->getMessage()

--- a/src/services/repositories/external/ConnectorJobRepository.php
+++ b/src/services/repositories/external/ConnectorJobRepository.php
@@ -10,6 +10,7 @@ use LiltConnectorSDK\ApiException;
 use LiltConnectorSDK\Model\JobResponse;
 use LiltConnectorSDK\Model\SettingsResponse;
 use LiltConnectorSDK\ObjectSerializer;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\parameters\CraftliltpluginParameters;
 
 class ConnectorJobRepository extends AbstractConnectorExternalRepository
@@ -39,7 +40,7 @@ class ConnectorJobRepository extends AbstractConnectorExternalRepository
             $this->handleException($ex);
             return false;
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => sprintf('Exception when calling JobsApi->servicesApiJobsAddFile: %s', $ex->getMessage()),
                 'exception_message' => $ex->getMessage(),
                 'exception_trace' => $ex->getTrace(),
@@ -102,7 +103,7 @@ class ConnectorJobRepository extends AbstractConnectorExternalRepository
                 $response = ObjectSerializer::deserialize($dataFromCache, JobResponse::class);
             }
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 "message" => sprintf(
                     'Deserialize error for lilt job %d: %s ',
                     $liltJobId,

--- a/src/services/repositories/external/ConnectorTranslationRepository.php
+++ b/src/services/repositories/external/ConnectorTranslationRepository.php
@@ -11,6 +11,7 @@ use LiltConnectorSDK\Model\JobResponse1 as ConnectorTranslationsResponse;
 use LiltConnectorSDK\Model\TranslationResponse;
 use LiltConnectorSDK\ObjectSerializer;
 use lilthq\craftliltplugin\exceptions\WrongTranslationFilenameException;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\parameters\CraftliltpluginParameters;
 
 class ConnectorTranslationRepository extends AbstractConnectorExternalRepository
@@ -101,7 +102,7 @@ class ConnectorTranslationRepository extends AbstractConnectorExternalRepository
                 $response = ObjectSerializer::deserialize($dataFromCache, ConnectorTranslationsResponse::class);
             }
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 "message" => sprintf(
                     'Deserialize error for lilt job %d: %s ',
                     $jobId,

--- a/src/utilities/Configuration.php
+++ b/src/utilities/Configuration.php
@@ -10,6 +10,7 @@ use craft\helpers\UrlHelper;
 use Exception;
 use LiltConnectorSDK\Model\SettingsResponse;
 use lilthq\craftliltplugin\Craftliltplugin;
+use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugin\records\SettingRecord;
 use lilthq\craftliltplugin\services\repositories\SettingsRepository;
 
@@ -39,7 +40,7 @@ class Configuration extends Utility
         try {
             $settingsResult = Craftliltplugin::getInstance()->connectorSettingsApi->servicesApiSettingsGetSettings();
         } catch (Exception $ex) {
-            Craft::error([
+            LiltLogger::error([
                 'message' => "Can't fetch setting from connector api!",
                 'exception_message' => $ex->getMessage(),
                 'exception_trace' => $ex->getTrace(),

--- a/tests/_support/Helper/Integration.php
+++ b/tests/_support/Helper/Integration.php
@@ -11,7 +11,9 @@
 
 namespace Helper;
 
+use Codeception\Exception\ModuleException;
 use Codeception\Module;
+use Codeception\Lib\JsonArray;
 
 /**
  * Class Unit
@@ -28,5 +30,39 @@ class Integration extends Module
 
         $this->assertTrue($response->headers->has($name));
         $this->assertSame($value, $response->headers->get($name));
+    }
+
+    /**
+     * @throws ModuleException
+     */
+    public function seeResponseIsJson(): void
+    {
+        $response = $this->getModule('Yii2')->_getResponseContent();
+        $this->assertJson($response, 'Response is not valid JSON');
+    }
+
+    /**
+     * @throws ModuleException
+     */
+    public function seeResponseContainsJson(array $subset): void
+    {
+        $response = $this->getModule('Yii2')->_getResponseContent();
+        $this->assertJson($response, 'Response is not valid JSON');
+        $actual = json_decode($response, true);
+        $this->assertArraySubset($subset, $actual, 'The JSON response does not contain the expected subset.');
+    }
+
+    protected function assertArraySubset(array $subset, array $array, string $message = ''): void
+    {
+        foreach ($subset as $key => $value) {
+            $this->assertArrayHasKey($key, $array, $message);
+
+            if (is_array($value)) {
+                $this->assertIsArray($array[$key], $message);
+                $this->assertArraySubset($value, $array[$key], $message);
+            } else {
+                $this->assertEquals($value, $array[$key], $message);
+            }
+        }
     }
 }

--- a/tests/_support/Helper/Integration.php
+++ b/tests/_support/Helper/Integration.php
@@ -31,38 +31,4 @@ class Integration extends Module
         $this->assertTrue($response->headers->has($name));
         $this->assertSame($value, $response->headers->get($name));
     }
-
-    /**
-     * @throws ModuleException
-     */
-    public function seeResponseIsJson(): void
-    {
-        $response = $this->getModule('Yii2')->_getResponseContent();
-        $this->assertJson($response, 'Response is not valid JSON');
-    }
-
-    /**
-     * @throws ModuleException
-     */
-    public function seeResponseContainsJson(array $subset): void
-    {
-        $response = $this->getModule('Yii2')->_getResponseContent();
-        $this->assertJson($response, 'Response is not valid JSON');
-        $actual = json_decode($response, true);
-        $this->assertArraySubset($subset, $actual, 'The JSON response does not contain the expected subset.');
-    }
-
-    protected function assertArraySubset(array $subset, array $array, string $message = ''): void
-    {
-        foreach ($subset as $key => $value) {
-            $this->assertArrayHasKey($key, $array, $message);
-
-            if (is_array($value)) {
-                $this->assertIsArray($array[$key], $message);
-                $this->assertArraySubset($value, $array[$key], $message);
-            } else {
-                $this->assertEquals($value, $array[$key], $message);
-            }
-        }
-    }
 }

--- a/tests/_support/Helper/SpyLogger.php
+++ b/tests/_support/Helper/SpyLogger.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * craft-lilt-plugin plugin for Craft CMS 3.x
+ *
+ * The Lilt plugin makes it easy for you to send content to Lilt for translation right from within Craft CMS.
+ *
+ * @link      https://github.com/lilt
+ * @copyright Copyright (c) 2025 Lilt Devs
+ */
+
+namespace Helper;
+
+use yii\log\Logger;
+
+class SpyLogger extends Logger
+{
+    /**
+     * @var array An array of all calls made to the log() method.
+     */
+    public array $calls = [];
+
+    /**
+     * @inheritdoc
+     */
+    public function log($message, $level, $category = 'application')
+    {
+        $this->calls[] = compact('message', 'level', 'category');
+    }
+}

--- a/tests/_support/Helper/WiremockClient.php
+++ b/tests/_support/Helper/WiremockClient.php
@@ -276,11 +276,13 @@ class WiremockClient extends Module
         );
     }
 
-    public function expectLogPostRequest(string $url, string $expectedMessage, int $responseCode): void
+    public function expectLogsPostRequest(string $expectedMessage, int $responseCode): void
     {
         $this->wireMock->stubFor(
-            WireMock::post(WireMock::urlPathMatching($url))
-                ->withRequestBody(WireMock::containing("\"message\":\"$expectedMessage\""))
+            WireMock::post(WireMock::urlEqualTo('/api/v1.0/logs'))
+                ->withRequestBody(
+                    WireMock::matchingJsonPath('$.message', WireMock::equalTo($expectedMessage))
+                )
                 ->willReturn(WireMock::aResponse()->withStatus($responseCode))
         );
     }

--- a/tests/_support/Helper/WiremockClient.php
+++ b/tests/_support/Helper/WiremockClient.php
@@ -275,4 +275,13 @@ class WiremockClient extends Module
             sprintf('Some of requests are unmatched: %s', json_encode($requests, JSON_PRETTY_PRINT))
         );
     }
+
+    public function expectLogPostRequest(string $url, string $expectedMessage, int $responseCode): void
+    {
+        $this->wireMock->stubFor(
+            WireMock::post(WireMock::urlPathMatching($url))
+                ->withRequestBody(WireMock::containing("\"message\":\"$expectedMessage\""))
+                ->willReturn(WireMock::aResponse()->withStatus($responseCode))
+        );
+    }
 }

--- a/tests/_support/IntegrationTester.php
+++ b/tests/_support/IntegrationTester.php
@@ -32,4 +32,32 @@ use Codeception\Lib\Friend;
 class IntegrationTester extends Actor
 {
     use _generated\IntegrationTesterActions;
+
+    /**
+     * @var array A temporary store for original application services that are being mocked.
+     */
+    private array $originalServices = [];
+
+    /**
+     * Backs up a core application service before it's replaced by a mock or spy.
+     *
+     * @param string $id The service ID (e.g., 'logger').
+     */
+    public function backupService(string $id): void
+    {
+        if (Craft::$app->has($id) && !isset($this->originalServices[$id])) {
+            $this->originalServices[$id] = Craft::$app->get($id);
+        }
+    }
+
+    /**
+     * Restores all backed-up services to their original state.
+     */
+    public function restoreOriginalServices(): void
+    {
+        foreach ($this->originalServices as $id => $service) {
+            Craft::$app->set($id, $service);
+        }
+        $this->originalServices = []; // Clear the array for the next test
+    }
 }

--- a/tests/integration/LiltLoggerCest.php
+++ b/tests/integration/LiltLoggerCest.php
@@ -62,6 +62,8 @@ class LiltLoggerCest extends AbstractIntegrationCest
         LiltLogger::error('Test error message');
         LiltLogger::logException(new RuntimeException('Test exception'));
 
+        Craftliltplugin::getInstance()->logsApi->flush();
+
         Assert::assertCount(2, $this->spyLogger->calls);
     }
 
@@ -75,6 +77,8 @@ class LiltLoggerCest extends AbstractIntegrationCest
 
         LiltLogger::info('Test info message');
         LiltLogger::logException(new RuntimeException('Test exception'));
+
+        Craftliltplugin::getInstance()->logsApi->flush();
 
         Assert::assertCount(2, $this->spyLogger->calls);
     }

--- a/tests/integration/LiltLoggerCest.php
+++ b/tests/integration/LiltLoggerCest.php
@@ -10,6 +10,7 @@ use IntegrationTester;
 use lilthq\craftliltplugin\Craftliltplugin;
 use lilthq\craftliltplugin\LiltLogger;
 use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
+use PHPUnit\Framework\Assert;
 use ReflectionClass;
 use RuntimeException;
 
@@ -47,7 +48,7 @@ class LiltLoggerCest extends AbstractIntegrationCest
         LiltLogger::info('Test info message');
         LiltLogger::warning('Test warning message');
 
-        $I->assertCount(2, $this->spyLogger->calls);
+        Assert::assertCount(2, $this->spyLogger->calls);
     }
 
     public function testErrorLogsAreSentWhenFlagIsTrue(IntegrationTester $I): void
@@ -56,12 +57,12 @@ class LiltLoggerCest extends AbstractIntegrationCest
         $this->setRemoteLogErrorsOnly(true);
 
         $I->expectLogsPostRequest('Test error message', 200);
-        $I->expectLogPsostRequest('Test exception', 200);
+        $I->expectLogsPostRequest('Test exception', 200);
 
         LiltLogger::error('Test error message');
         LiltLogger::logException(new RuntimeException('Test exception'));
 
-        $I->assertCount(2, $this->spyLogger->calls);
+        Assert::assertCount(2, $this->spyLogger->calls);
     }
 
     public function testAllLogsAreSentWhenFlagIsFalse(IntegrationTester $I): void
@@ -75,6 +76,6 @@ class LiltLoggerCest extends AbstractIntegrationCest
         LiltLogger::info('Test info message');
         LiltLogger::logException(new RuntimeException('Test exception'));
 
-        $I->assertCount(2, $this->spyLogger->calls);
+        Assert::assertCount(2, $this->spyLogger->calls);
     }
 }

--- a/tests/integration/LiltLoggerCest.php
+++ b/tests/integration/LiltLoggerCest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace lilthq\craftliltplugintests\integration\utilities;
+
+use Craft;
+use Helper\SpyLogger;
+use IntegrationTester;
+use lilthq\craftliltplugin\Craftliltplugin;
+use lilthq\craftliltplugin\LiltLogger;
+use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
+use ReflectionClass;
+use RuntimeException;
+
+class LiltLoggerCest extends AbstractIntegrationCest
+{
+    private ?SpyLogger $spyLogger = null;
+
+    public function _before(IntegrationTester $I): void
+    {
+        parent::_before($I);
+
+        $I->backupService('logger');
+
+        $this->spyLogger = new SpyLogger();
+        Craft::$app->set('logger', $this->spyLogger);
+    }
+
+    public function _after(IntegrationTester $I): void
+    {
+        $I->restoreOriginalServices();
+        parent::_after($I);
+    }
+
+    private function setRemoteLogErrorsOnly(bool $value): void
+    {
+        $reflection = new ReflectionClass(Craftliltplugin::class);
+        $reflection->setStaticPropertyValue('REMOTE_LOG_ERRORS_ONLY', $value);
+    }
+
+    public function testNonErrorLogsAreOnlyLocalWhenFlagIsTrue(IntegrationTester $I): void
+    {
+        $I->wantTo('verify that info/debug/warning logs are only local when REMOTE_LOG_ERRORS_ONLY is true');
+        $this->setRemoteLogErrorsOnly(true);
+
+        LiltLogger::info('Test info message');
+        LiltLogger::warning('Test warning message');
+
+        $I->assertCount(2, $this->spyLogger->calls);
+    }
+
+    public function testErrorLogsAreSentWhenFlagIsTrue(IntegrationTester $I): void
+    {
+        $I->wantTo('verify that error logs are sent remotely when REMOTE_LOG_ERRORS_ONLY is true');
+        $this->setRemoteLogErrorsOnly(true);
+
+        $I->expectLogPostRequest('Test error message', 200);
+        $I->expectLogPostRequest('Test exception', 200);
+
+        LiltLogger::error('Test error message');
+        LiltLogger::logException(new RuntimeException('Test exception'));
+
+        $I->assertCount(2, $this->spyLogger->calls);
+    }
+
+    public function testAllLogsAreSentWhenFlagIsFalse(IntegrationTester $I): void
+    {
+        $I->wantTo('verify that all log levels are sent remotely when REMOTE_LOG_ERRORS_ONLY is false');
+        $this->setRemoteLogErrorsOnly(false);
+
+        $I->expectLogPostRequest('Test info message', 200);
+        $I->expectLogPostRequest('Test exception', 200);
+
+        LiltLogger::info('Test info message');
+        LiltLogger::logException(new RuntimeException('Test exception'));
+
+        $I->assertCount(2, $this->spyLogger->calls);
+    }
+}

--- a/tests/integration/LiltLoggerCest.php
+++ b/tests/integration/LiltLoggerCest.php
@@ -55,8 +55,8 @@ class LiltLoggerCest extends AbstractIntegrationCest
         $I->wantTo('verify that error logs are sent remotely when REMOTE_LOG_ERRORS_ONLY is true');
         $this->setRemoteLogErrorsOnly(true);
 
-        $I->expectLogPostRequest('Test error message', 200);
-        $I->expectLogPostRequest('Test exception', 200);
+        $I->expectLogsPostRequest('Test error message', 200);
+        $I->expectLogPsostRequest('Test exception', 200);
 
         LiltLogger::error('Test error message');
         LiltLogger::logException(new RuntimeException('Test exception'));
@@ -69,8 +69,8 @@ class LiltLoggerCest extends AbstractIntegrationCest
         $I->wantTo('verify that all log levels are sent remotely when REMOTE_LOG_ERRORS_ONLY is false');
         $this->setRemoteLogErrorsOnly(false);
 
-        $I->expectLogPostRequest('Test info message', 200);
-        $I->expectLogPostRequest('Test exception', 200);
+        $I->expectLogsPostRequest('Test info message', 200);
+        $I->expectLogsPostRequest('Test exception', 200);
 
         LiltLogger::info('Test info message');
         LiltLogger::logException(new RuntimeException('Test exception'));

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -6,36 +6,32 @@ namespace lilthq\craftliltplugin\controllers {
     use yii\web\Response;
     use RuntimeException;
 
-    class TestErrorController extends PluginController
-    {
-        protected array|int|bool $allowAnonymous = true;
-
-        public function beforeAction($action): bool
+    if (!class_exists(TestErrorController::class)) {
+        class TestErrorController extends PluginController
         {
-            if ($action->id === 'error-in-before-action') {
-                throw new RuntimeException('This is a test beforeAction error.');
+            protected array|int|bool $allowAnonymous = true;
+
+            public function beforeAction($action): bool
+            {
+                if ($action->id === 'error-in-before-action') {
+                    throw new RuntimeException('This is a test beforeAction error.');
+                }
+                return parent::beforeAction($action);
             }
-            return parent::beforeAction($action);
-        }
 
-        public function actionErrorInRunAction(): Response
-        {
-            throw new RuntimeException('This is a test runAction error.');
+            public function actionErrorInRunAction(): Response
+            {
+                throw new RuntimeException('This is a test runAction error.');
+            }
         }
     }
 }
 
-// This is the actual test suite namespace.
 namespace lilthq\craftliltplugintests\integration\controllers {
-
     use Craft;
-    use Exception;
     use IntegrationTester;
     use lilthq\craftliltplugin\controllers\TestErrorController;
-    use lilthq\craftliltplugin\Craftliltplugin;
-    use lilthq\craftliltplugin\services\LogsApi;
     use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
-    use PHPUnit\Framework\MockObject\MockObject;
 
     class PluginControllerCest extends AbstractIntegrationCest
     {
@@ -49,16 +45,15 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         {
             parent::_after($I);
             unset(Craft::$app->controllerMap['test-error']);
-            Craftliltplugin::setInstance(null);
-            Craft::$app->set('craftliltplugin', null);
         }
 
         public function testRunActionCatchesError(IntegrationTester $I): void
         {
-            /** @var MockObject|LogsApi $logsApiMock */
-            $logsApiMock = $this->createMock(LogsApi::class);
-            $logsApiMock->expects($I->once())->method('postLog');
-            $this->mockPluginService($logsApiMock);
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'This is a test runAction error.',
+                200
+            );
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
 
@@ -72,15 +67,11 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
         public function testBeforeActionCatchesError(IntegrationTester $I): void
         {
-            /** @var MockObject|LogsApi $logsApiMock */
-            $logsApiMock = $this->createMock(LogsApi::class);
-            $logsApiMock->expects($I->once())
-                ->method('postLog')
-                ->with(
-                    $I->equalTo('error-in-before-action'),
-                    $I->equalTo('This is a test beforeAction error.')
-                );
-            $this->mockPluginService($logsApiMock);
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'This is a test beforeAction error.',
+                200
+            );
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
 
@@ -89,24 +80,16 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
         public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
         {
-            /** @var MockObject|LogsApi $logsApiMock */
-            $logsApiMock = $this->createMock(LogsApi::class);
-            $logsApiMock->expects($I->once())
-                ->method('postLog')
-                ->willThrowException(new Exception('Remote API is down.'));
-            $this->mockPluginService($logsApiMock);
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'This is a test runAction error.',
+                500
+            );
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
 
             $I->seeResponseCodeIs(200);
             $I->seeResponseContainsJson(['message' => 'This is a test runAction error.']);
-        }
-
-        private function mockPluginService(LogsApi|MockObject $logsApiMock): void
-        {
-            $pluginMock = $this->createMock(Craftliltplugin::class);
-            $pluginMock->logsApi = $logsApiMock;
-            Craftliltplugin::setInstance($pluginMock);
         }
     }
 }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -2,9 +2,6 @@
 
 declare(strict_types=1);
 
-// By defining this class in the plugin's actual controllers namespace, we can
-// create a test-specific controller that correctly extends PluginController
-// without adding it to the production source code.
 namespace lilthq\craftliltplugin\controllers {
     use yii\web\Response;
     use RuntimeException;
@@ -13,10 +10,6 @@ namespace lilthq\craftliltplugin\controllers {
     {
         protected array|int|bool $allowAnonymous = true;
 
-        /**
-         * Overrides the parent to throw an error for a specific action ID.
-         * This allows us to test the error handling in the base `beforeAction`.
-         */
         public function beforeAction($action): bool
         {
             if ($action->id === 'error-in-before-action') {
@@ -25,9 +18,6 @@ namespace lilthq\craftliltplugin\controllers {
             return parent::beforeAction($action);
         }
 
-        /**
-         * An action designed to fail to test the `runAction` error handling.
-         */
         public function actionErrorInRunAction(): Response
         {
             throw new RuntimeException('This is a test runAction error.');
@@ -66,7 +56,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         public function testRunActionCatchesError(IntegrationTester $I): void
         {
             /** @var MockObject|LogsApi $logsApiMock */
-            $logsApiMock = $I->make(LogsApi::class);
+            $logsApiMock = $this->createMock(LogsApi::class);
             $logsApiMock->expects($I->once())->method('postLog');
             $this->mockPluginService($logsApiMock);
 
@@ -83,7 +73,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         public function testBeforeActionCatchesError(IntegrationTester $I): void
         {
             /** @var MockObject|LogsApi $logsApiMock */
-            $logsApiMock = $I->make(LogsApi::class);
+            $logsApiMock = $this->createMock(LogsApi::class);
             $logsApiMock->expects($I->once())
                 ->method('postLog')
                 ->with(
@@ -100,7 +90,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
         {
             /** @var MockObject|LogsApi $logsApiMock */
-            $logsApiMock = $I->make(LogsApi::class);
+            $logsApiMock = $this->createMock(LogsApi::class);
             $logsApiMock->expects($I->once())
                 ->method('postLog')
                 ->willThrowException(new Exception('Remote API is down.'));

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -3,31 +3,31 @@
 declare(strict_types=1);
 
 namespace lilthq\craftliltplugin\controllers {
-    use yii\web\Response;
+
     use RuntimeException;
+    use yii\web\Response;
 
-    if (!class_exists(TestErrorController::class)) {
-        class TestErrorController extends PluginController
+    class TestErrorController extends PluginController
+    {
+        protected array|int|bool $allowAnonymous = true;
+
+        public function beforeAction($action): bool
         {
-            protected array|int|bool $allowAnonymous = true;
-
-            public function beforeAction($action): bool
-            {
-                if ($action->id === 'error-in-before-action') {
-                    throw new RuntimeException('This is a test beforeAction error.');
-                }
-                return parent::beforeAction($action);
+            if ($action->id === 'error-in-before-action') {
+                throw new RuntimeException('This is a test beforeAction error.');
             }
+            return parent::beforeAction($action);
+        }
 
-            public function actionErrorInRunAction(): Response
-            {
-                throw new RuntimeException('This is a test runAction error.');
-            }
+        public function actionErrorInRunAction(): Response
+        {
+            throw new RuntimeException('This is a test runAction error.');
         }
     }
 }
 
 namespace lilthq\craftliltplugintests\integration\controllers {
+
     use Craft;
     use IntegrationTester;
     use lilthq\craftliltplugin\controllers\TestErrorController;

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -83,12 +83,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
                 200
             );
 
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'Unable to resolve the request: test-error/error-in-run-action',
-                200
-            );
-
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action', []);
 
             $I->seeResponseCodeIs(200);

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace lilthq\craftliltplugin\controllers {
 
     use RuntimeException;
+    use yii\filters\AccessControl;
     use yii\web\Response;
 
     if (!class_exists(TestErrorController::class)) {
@@ -12,12 +13,19 @@ namespace lilthq\craftliltplugin\controllers {
         {
             protected array|int|bool $allowAnonymous = true;
 
-            public function beforeAction($action): bool
+            public function behaviors(): array
             {
-                if ($action->id === 'error-in-before-action') {
-                    throw new RuntimeException('This is a test beforeAction error.');
-                }
-                return parent::beforeAction($action);
+                return [
+                    'access' => [
+                        'class' => AccessControl::class,
+                        'rules' => [
+                            [
+                                'actions' => ['access-denied'],
+                                'allow' => false,
+                            ],
+                        ],
+                    ],
+                ];
             }
 
             public function actionErrorInRunAction(): Response
@@ -25,8 +33,9 @@ namespace lilthq\craftliltplugin\controllers {
                 throw new RuntimeException('This is a test runAction error.');
             }
 
-            public function actionErrorViaEvent(): Response
+            public function actionAccessDenied(): Response
             {
+                // This action will never be reached.
                 return $this->asJson(['success' => true]);
             }
         }
@@ -40,8 +49,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
     use lilthq\craftliltplugin\controllers\TestErrorController;
     use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
     use PHPUnit\Framework\Assert;
-    use yii\base\Event;
-    use craft\web\Controller;
 
     class PluginControllerCest extends AbstractIntegrationCest
     {
@@ -49,62 +56,12 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         {
             parent::_before($I);
             Craft::$app->controllerMap['test-error'] = TestErrorController::class;
-
-            Event::on(
-                Controller::class,
-                Controller::EVENT_BEFORE_ACTION,
-                function($event) {
-                    if ($event->sender instanceof TestErrorController && $event->action->id === 'error-via-event') {
-                        throw new \RuntimeException('Error from event handler');
-                    }
-                }
-            );
         }
 
         public function _after(IntegrationTester $I): void
         {
             parent::_after($I);
             unset(Craft::$app->controllerMap['test-error']);
-
-            Event::off(Controller::class, Controller::EVENT_BEFORE_ACTION);
-        }
-
-        public function testRunActionCatchesBeforeActionErrorFromChild(IntegrationTester $I): void
-        {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'This is a test beforeAction error.',
-                200
-            );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
-
-            $I->seeResponseCodeIs(200);
-            $responseContent = Craft::$app->getResponse()->content;
-            $response = json_decode($responseContent, true);
-
-            Assert::assertIsArray($response);
-            Assert::assertFalse($response['success']);
-            Assert::assertSame(
-                'Unable to resolve the request: test-error/error-in-before-action',
-                $response['message']
-            );
-        }
-
-        public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
-        {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'This is a test runAction error.',
-                500
-            );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-            $I->seeResponseCodeIs(200);
-
-            $responseContent = Craft::$app->getResponse()->content;
-            $response = json_decode($responseContent, true);
-            Assert::assertSame('This is a test runAction error.', $response['message']);
         }
 
         public function testRunActionCatchesError(IntegrationTester $I): void
@@ -126,23 +83,34 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             Assert::assertSame('This is a test runAction error.', $response['message']);
         }
 
-        public function testBeforeActionCatchesInternalFrameworkError(IntegrationTester $I): void
+        public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
         {
             $I->expectLogPostRequest(
                 '/api/v1.0/logs',
-                'Error from event handler',
-                200
+                'This is a test runAction error.',
+                500
             );
 
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+            $I->seeResponseCodeIs(200);
+
+            $responseContent = Craft::$app->getResponse()->content;
+            $response = json_decode($responseContent, true);
+            Assert::assertSame('This is a test runAction error.', $response['message']);
+        }
+
+        public function testBeforeActionCatchesAccessDeniedError(IntegrationTester $I): void
+        {
             $I->expectLogPostRequest(
                 '/api/v1.0/logs',
-                'Unable to resolve the request: test-error/error-via-event',
+                'You are not allowed to perform this action.',
                 200
             );
 
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-via-event');
+            $I->sendAjaxPostRequest('index.php?action=test-error/access-denied');
 
-            $I->seeResponseCodeIs(404);
+            $I->seeResponseCodeIs(403);
         }
     }
 }
+

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -142,14 +142,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-via-event');
 
-            $I->seeResponseCodeIs(200);
-            $response = json_decode(Craft::$app->getResponse()->content, true);
-
-            Assert::assertFalse($response['success']);
-            Assert::assertSame(
-                'Unable to resolve the request: test-error/error-via-event',
-                $response['message']
-            );
+            $I->seeResponseCodeIs(404);
         }
     }
 }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -95,10 +95,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $response = json_decode(Craft::$app->getResponse()->content, true);
 
             Assert::assertFalse($response['success']);
-            Assert::assertSame(
-                'Unable to resolve the request: test-error/error-in-run-action',
-                $response['message']
-            );
+            Assert::assertSame('This is a test runAction error.', $response['message']);
 
             $request->enableCsrfValidation = false;
         }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -43,27 +43,30 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
         public function testRunActionLogsAndRethrowsError(IntegrationTester $I): void
         {
-            $I->expectLogsPostRequest(
-                'This is a test runAction error.',
-                200
+            $I->wantTo('verify it logs the error and then re-throws the original exception');
+
+            $I->expectLogPostRequest('This is a test runAction error.', 200);
+
+            $I->expectThrowable(
+                new RuntimeException('This is a test runAction error.'),
+                function() use ($I) {
+                    $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+                }
             );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-
-            $I->seeResponseCodeIs(500);
-            $I->seeInSource('This is a test runAction error.');
         }
 
         public function testApiLoggingFailureDoesNotPreventException(IntegrationTester $I): void
         {
-            $I->expectLogsPostRequest(
-                'This is a test runAction error.',
-                500
+            $I->wantTo('verify a remote logging failure doesn\'t prevent the exception');
+
+            $I->expectLogPostRequest('This is a test runAction error.', 500);
+
+            $I->expectThrowable(
+                new RuntimeException('This is a test runAction error.'),
+                function() use ($I) {
+                    $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+                }
             );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-
-            $I->seeResponseCodeIs(500);
         }
     }
 }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -48,7 +48,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $I->expectLogsPostRequest('This is a test runAction error.', 200);
 
             $I->expectThrowable(
-                new RuntimeException('This is a test runAction error.'),
+                new \RuntimeException('This is a test runAction error.'),
                 function() use ($I) {
                     $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
                 }
@@ -62,7 +62,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $I->expectLogsPostRequest('This is a test runAction error.', 500);
 
             $I->expectThrowable(
-                new RuntimeException('This is a test runAction error.'),
+                new \RuntimeException('This is a test runAction error.'),
                 function() use ($I) {
                     $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
                 }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 namespace lilthq\craftliltplugin\controllers {
+
     use RuntimeException;
     use yii\web\Response;
 
@@ -33,6 +34,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
     use IntegrationTester;
     use lilthq\craftliltplugin\controllers\TestErrorController;
     use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
+    use PHPUnit\Framework\Assert;
 
     class PluginControllerCest extends AbstractIntegrationCest
     {
@@ -62,11 +64,11 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $responseContent = Craft::$app->getResponse()->content;
             $response = json_decode($responseContent, true);
 
-            $I->assertIsArray($response);
-            $I->assertArrayHasKey('success', $response);
-            $I->assertArrayHasKey('message', $response);
-            $I->assertFalse($response['success']);
-            $I->assertSame('This is a test runAction error.', $response['message']);
+            Assert::assertIsArray($response);
+            Assert::assertArrayHasKey('success', $response);
+            Assert::assertArrayHasKey('message', $response);
+            Assert::assertFalse($response['success']);
+            Assert::assertSame('This is a test runAction error.', $response['message']);
         }
 
         public function testBeforeActionCatchesError(IntegrationTester $I): void
@@ -80,7 +82,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
 
             $I->seeResponseCodeIs(200);
-            $I->assertEmpty(Craft::$app->getResponse()->content);
+            Assert::assertEmpty(Craft::$app->getResponse()->content);
         }
 
         public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
@@ -96,7 +98,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             $responseContent = Craft::$app->getResponse()->content;
             $response = json_decode($responseContent, true);
-            $I->assertSame('This is a test runAction error.', $response['message']);
+            Assert::assertSame('This is a test runAction error.', $response['message']);
         }
     }
 }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -59,7 +59,8 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
             $I->seeResponseCodeIs(200);
 
-            $response = json_decode($I->grabResponse(), true);
+            $responseContent = Craft::$app->getResponse()->content;
+            $response = json_decode($responseContent, true);
 
             $I->assertIsArray($response);
             $I->assertArrayHasKey('success', $response);
@@ -79,7 +80,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
 
             $I->seeResponseCodeIs(200);
-            $I->assertEmpty($I->grabResponse());
+            $I->assertEmpty(Craft::$app->getResponse()->content);
         }
 
         public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
@@ -93,7 +94,8 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
             $I->seeResponseCodeIs(200);
 
-            $response = json_decode($I->grabResponse(), true);
+            $responseContent = Craft::$app->getResponse()->content;
+            $response = json_decode($responseContent, true);
             $I->assertSame('This is a test runAction error.', $response['message']);
         }
     }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -50,6 +50,25 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             unset(Craft::$app->controllerMap['test-error']);
         }
 
+        public function testBeforeActionCatchesError(IntegrationTester $I): void
+        {
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'This is a test beforeAction error.',
+                200
+            );
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
+
+            $I->seeResponseCodeIs(200);
+            $responseContent = Craft::$app->getResponse()->content;
+            $response = json_decode($responseContent, true);
+
+            Assert::assertIsArray($response);
+            Assert::assertFalse($response['success']);
+            Assert::assertSame('This is a test beforeAction error.', $response['message']);
+        }
+
         public function testRunActionCatchesError(IntegrationTester $I): void
         {
             $I->expectLogPostRequest(
@@ -69,20 +88,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             Assert::assertArrayHasKey('message', $response);
             Assert::assertFalse($response['success']);
             Assert::assertSame('This is a test runAction error.', $response['message']);
-        }
-
-        public function testBeforeActionCatchesError(IntegrationTester $I): void
-        {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'This is a test beforeAction error.',
-                200
-            );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
-
-            $I->seeResponseCodeIs(200);
-            Assert::assertEmpty(Craft::$app->getResponse()->content);
         }
 
         public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -72,6 +72,37 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             );
         }
 
+        public function testBeforeActionCatchesInternalError(IntegrationTester $I): void
+        {
+            $request = Craft::$app->getRequest();
+            $request->enableCsrfValidation = true;
+
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'Unable to verify your data submission.',
+                200
+            );
+
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'Unable to resolve the request: test-error/error-in-run-action',
+                200
+            );
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action', []);
+
+            $I->seeResponseCodeIs(200);
+            $response = json_decode(Craft::$app->getResponse()->content, true);
+
+            Assert::assertFalse($response['success']);
+            Assert::assertSame(
+                'Unable to resolve the request: test-error/error-in-run-action',
+                $response['message']
+            );
+
+            $request->enableCsrfValidation = false;
+        }
+
         public function testRunActionCatchesError(IntegrationTester $I): void
         {
             $I->expectLogPostRequest(

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -3,25 +3,26 @@
 declare(strict_types=1);
 
 namespace lilthq\craftliltplugin\controllers {
-
     use RuntimeException;
     use yii\web\Response;
 
-    class TestErrorController extends PluginController
-    {
-        protected array|int|bool $allowAnonymous = true;
-
-        public function beforeAction($action): bool
+    if (!class_exists(TestErrorController::class)) {
+        class TestErrorController extends PluginController
         {
-            if ($action->id === 'error-in-before-action') {
-                throw new RuntimeException('This is a test beforeAction error.');
+            protected array|int|bool $allowAnonymous = true;
+
+            public function beforeAction($action): bool
+            {
+                if ($action->id === 'error-in-before-action') {
+                    throw new RuntimeException('This is a test beforeAction error.');
+                }
+                return parent::beforeAction($action);
             }
-            return parent::beforeAction($action);
-        }
 
-        public function actionErrorInRunAction(): Response
-        {
-            throw new RuntimeException('This is a test runAction error.');
+            public function actionErrorInRunAction(): Response
+            {
+                throw new RuntimeException('This is a test runAction error.');
+            }
         }
     }
 }
@@ -56,13 +57,15 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             );
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-
             $I->seeResponseCodeIs(200);
-            $I->seeResponseIsJson();
-            $I->seeResponseContainsJson([
-                'success' => false,
-                'message' => 'This is a test runAction error.',
-            ]);
+
+            $response = json_decode($I->grabResponse(), true);
+
+            $I->assertIsArray($response);
+            $I->assertArrayHasKey('success', $response);
+            $I->assertArrayHasKey('message', $response);
+            $I->assertFalse($response['success']);
+            $I->assertSame('This is a test runAction error.', $response['message']);
         }
 
         public function testBeforeActionCatchesError(IntegrationTester $I): void
@@ -75,7 +78,8 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
 
-            $I->seeResponseCodeIs(404);
+            $I->seeResponseCodeIs(200);
+            $I->assertEmpty($I->grabResponse());
         }
 
         public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
@@ -87,9 +91,10 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             );
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-
             $I->seeResponseCodeIs(200);
-            $I->seeResponseContainsJson(['message' => 'This is a test runAction error.']);
+
+            $response = json_decode($I->grabResponse(), true);
+            $I->assertSame('This is a test runAction error.', $response['message']);
         }
     }
 }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -26,6 +26,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
     use IntegrationTester;
     use lilthq\craftliltplugin\controllers\TestErrorController;
     use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
+    use PHPUnit\Framework\Assert;
 
     class PluginControllerCest extends AbstractIntegrationCest
     {
@@ -47,12 +48,11 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             $I->expectLogsPostRequest('This is a test runAction error.', 200);
 
-            $I->expectThrowable(
-                new \RuntimeException('This is a test runAction error.'),
-                function() use ($I) {
-                    $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-                }
-            );
+            try {
+                $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+            } catch (\RuntimeException $e) {
+                Assert::assertEquals('This is a test runAction error.', $e->getMessage());
+            }
         }
 
         public function testApiLoggingFailureDoesNotPreventException(IntegrationTester $I): void
@@ -61,12 +61,11 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             $I->expectLogsPostRequest('This is a test runAction error.', 500);
 
-            $I->expectThrowable(
-                new \RuntimeException('This is a test runAction error.'),
-                function() use ($I) {
-                    $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-                }
-            );
+            try {
+                $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+            } catch (\RuntimeException $e) {
+                Assert::assertEquals('This is a test runAction error.', $e->getMessage());
+            }
         }
     }
 }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+// By defining this class in the plugin's actual controllers namespace, we can
+// create a test-specific controller that correctly extends PluginController
+// without adding it to the production source code.
 namespace lilthq\craftliltplugin\controllers {
     use yii\web\Response;
     use RuntimeException;
@@ -10,6 +13,10 @@ namespace lilthq\craftliltplugin\controllers {
     {
         protected array|int|bool $allowAnonymous = true;
 
+        /**
+         * Overrides the parent to throw an error for a specific action ID.
+         * This allows us to test the error handling in the base `beforeAction`.
+         */
         public function beforeAction($action): bool
         {
             if ($action->id === 'error-in-before-action') {
@@ -18,6 +25,9 @@ namespace lilthq\craftliltplugin\controllers {
             return parent::beforeAction($action);
         }
 
+        /**
+         * An action designed to fail to test the `runAction` error handling.
+         */
         public function actionErrorInRunAction(): Response
         {
             throw new RuntimeException('This is a test runAction error.');
@@ -25,6 +35,7 @@ namespace lilthq\craftliltplugin\controllers {
     }
 }
 
+// This is the actual test suite namespace.
 namespace lilthq\craftliltplugintests\integration\controllers {
 
     use Craft;
@@ -35,55 +46,24 @@ namespace lilthq\craftliltplugintests\integration\controllers {
     use lilthq\craftliltplugin\services\LogsApi;
     use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
     use PHPUnit\Framework\MockObject\MockObject;
-    use yii\log\FileTarget;
-    use yii\log\Logger;
 
     class PluginControllerCest extends AbstractIntegrationCest
     {
-        private ?Logger $originalLogger;
-        private ?string $testLogPath;
-
         public function _before(IntegrationTester $I): void
         {
             parent::_before($I);
-
             Craft::$app->controllerMap['test-error'] = TestErrorController::class;
-
-            $this->originalLogger = Craft::getLogger();
-            $this->testLogPath = Craft::getAlias('@storage/logs/test-web.log');
-            if (file_exists($this->testLogPath)) {
-                unlink($this->testLogPath);
-            }
-
-            $testLogger = new Logger();
-            $testLogger->targets['test-file'] = new FileTarget([
-                'logFile' => $this->testLogPath,
-                'levels' => ['error', 'warning', 'info', 'trace'],
-                'logVars' => [],
-            ]);
-
-            Craft::setLogger($testLogger);
         }
 
         public function _after(IntegrationTester $I): void
         {
             parent::_after($I);
-
             unset(Craft::$app->controllerMap['test-error']);
-
-            if ($this->originalLogger) {
-                Craft::setLogger($this->originalLogger);
-            }
-
-            if ($this->testLogPath && file_exists($this->testLogPath)) {
-                unlink($this->testLogPath);
-            }
-
             Craftliltplugin::setInstance(null);
             Craft::$app->set('craftliltplugin', null);
         }
 
-        public function testRunActionCatchesAndLogsError(IntegrationTester $I): void
+        public function testRunActionCatchesError(IntegrationTester $I): void
         {
             /** @var MockObject|LogsApi $logsApiMock */
             $logsApiMock = $I->make(LogsApi::class);
@@ -98,14 +78,9 @@ namespace lilthq\craftliltplugintests\integration\controllers {
                 'success' => false,
                 'message' => 'This is a test runAction error.',
             ]);
-
-            $I->openFile($this->testLogPath);
-            $I->seeInThisFile('Controller error:');
-            $I->seeInThisFile('"event":"error-in-run-action"');
-            $I->seeInThisFile('"message":"This is a test runAction error."');
         }
 
-        public function testBeforeActionCatchesAndLogsError(IntegrationTester $I): void
+        public function testBeforeActionCatchesError(IntegrationTester $I): void
         {
             /** @var MockObject|LogsApi $logsApiMock */
             $logsApiMock = $I->make(LogsApi::class);
@@ -120,14 +95,9 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
 
             $I->seeResponseCodeIs(404);
-
-            $I->openFile($this->testLogPath);
-            $I->seeInThisFile('Controller error:');
-            $I->seeInThisFile('"event":"error-in-before-action"');
-            $I->seeInThisFile('"message":"This is a test beforeAction error."');
         }
 
-        public function testHandleErrorLogsApiFailureFailsafe(IntegrationTester $I): void
+        public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
         {
             /** @var MockObject|LogsApi $logsApiMock */
             $logsApiMock = $I->make(LogsApi::class);
@@ -140,12 +110,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             $I->seeResponseCodeIs(200);
             $I->seeResponseContainsJson(['message' => 'This is a test runAction error.']);
-
-            $I->openFile($this->testLogPath);
-            $I->seeInThisFile('Controller error:');
-            $I->seeInThisFile('"message":"This is a test runAction error."');
-            $I->seeInThisFile('Failed to send log to API. Reason:');
-            $I->seeInThisFile('"message":"Remote API is down."');
         }
 
         private function mockPluginService(LogsApi|MockObject $logsApiMock): void

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -45,7 +45,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         {
             $I->wantTo('verify it logs the error and then re-throws the original exception');
 
-            $I->expectLogPostRequest('This is a test runAction error.', 200);
+            $I->expectLogsPostRequest('This is a test runAction error.', 200);
 
             $I->expectThrowable(
                 new RuntimeException('This is a test runAction error.'),
@@ -59,7 +59,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         {
             $I->wantTo('verify a remote logging failure doesn\'t prevent the exception');
 
-            $I->expectLogPostRequest('This is a test runAction error.', 500);
+            $I->expectLogsPostRequest('This is a test runAction error.', 500);
 
             $I->expectThrowable(
                 new RuntimeException('This is a test runAction error.'),

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -23,6 +23,9 @@ namespace lilthq\craftliltplugin\controllers {
                                 'actions' => ['access-denied'],
                                 'allow' => false,
                             ],
+                            [
+                                'allow' => true,
+                            ],
                         ],
                     ],
                 ];
@@ -55,6 +58,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         public function _before(IntegrationTester $I): void
         {
             parent::_before($I);
+            // Registers the temporary TestErrorController for testing purposes.
             Craft::$app->controllerMap['test-error'] = TestErrorController::class;
         }
 
@@ -62,6 +66,19 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         {
             parent::_after($I);
             unset(Craft::$app->controllerMap['test-error']);
+        }
+
+        public function testBeforeActionCatchesAccessDeniedError(IntegrationTester $I): void
+        {
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'You are not allowed to perform this action.',
+                200
+            );
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/access-denied');
+
+            $I->seeResponseCodeIs(403);
         }
 
         public function testRunActionCatchesError(IntegrationTester $I): void
@@ -82,7 +99,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             Assert::assertFalse($response['success']);
             Assert::assertSame('This is a test runAction error.', $response['message']);
         }
-
         public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
         {
             $I->expectLogPostRequest(
@@ -98,19 +114,5 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $response = json_decode($responseContent, true);
             Assert::assertSame('This is a test runAction error.', $response['message']);
         }
-
-        public function testBeforeActionCatchesAccessDeniedError(IntegrationTester $I): void
-        {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'You are not allowed to perform this action.',
-                200
-            );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/access-denied');
-
-            $I->seeResponseCodeIs(403);
-        }
     }
 }
-

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -66,7 +66,10 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             Assert::assertIsArray($response);
             Assert::assertFalse($response['success']);
-            Assert::assertSame('This is a test beforeAction error.', $response['message']);
+            Assert::assertSame(
+                'Unable to resolve the request: test-error/error-in-before-action',
+                $response['message']
+            );
         }
 
         public function testRunActionCatchesError(IntegrationTester $I): void

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace lilthq\craftliltplugin\controllers {
 
     use RuntimeException;
-    use yii\filters\AccessControl;
     use yii\web\Response;
 
     if (!class_exists(TestErrorController::class)) {
@@ -13,33 +12,9 @@ namespace lilthq\craftliltplugin\controllers {
         {
             protected array|int|bool $allowAnonymous = true;
 
-            public function behaviors(): array
-            {
-                return [
-                    'access' => [
-                        'class' => AccessControl::class,
-                        'rules' => [
-                            [
-                                'actions' => ['access-denied'],
-                                'allow' => false,
-                            ],
-                            [
-                                'allow' => true,
-                            ],
-                        ],
-                    ],
-                ];
-            }
-
             public function actionErrorInRunAction(): Response
             {
                 throw new RuntimeException('This is a test runAction error.');
-            }
-
-            public function actionAccessDenied(): Response
-            {
-                // This action will never be reached.
-                return $this->asJson(['success' => true]);
             }
         }
     }
@@ -58,7 +33,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         public function _before(IntegrationTester $I): void
         {
             parent::_before($I);
-            // Registers the temporary TestErrorController for testing purposes.
             Craft::$app->controllerMap['test-error'] = TestErrorController::class;
         }
 
@@ -66,18 +40,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         {
             parent::_after($I);
             unset(Craft::$app->controllerMap['test-error']);
-        }
-
-        public function testBeforeActionCatchesAccessDeniedError(IntegrationTester $I): void
-        {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'You are not allowed to perform this action.',
-                200
-            );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/access-denied');
-            $I->seeResponseCodeIs(404);
         }
 
         public function testRunActionCatchesError(IntegrationTester $I): void

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -26,7 +26,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
     use IntegrationTester;
     use lilthq\craftliltplugin\controllers\TestErrorController;
     use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
-    use PHPUnit\Framework\Assert;
 
     class PluginControllerCest extends AbstractIntegrationCest
     {
@@ -42,38 +41,29 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             unset(Craft::$app->controllerMap['test-error']);
         }
 
-        public function testRunActionCatchesError(IntegrationTester $I): void
+        public function testRunActionLogsAndRethrowsError(IntegrationTester $I): void
         {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
+            $I->expectLogsPostRequest(
                 'This is a test runAction error.',
                 200
             );
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-            $I->seeResponseCodeIs(200);
 
-            $responseContent = Craft::$app->getResponse()->content;
-            $response = json_decode($responseContent, true);
-
-            Assert::assertIsArray($response);
-            Assert::assertFalse($response['success']);
-            Assert::assertSame('This is a test runAction error.', $response['message']);
+            $I->seeResponseCodeIs(500);
+            $I->seeInSource('This is a test runAction error.');
         }
-        public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
+
+        public function testApiLoggingFailureDoesNotPreventException(IntegrationTester $I): void
         {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
+            $I->expectLogsPostRequest(
                 'This is a test runAction error.',
                 500
             );
 
             $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-            $I->seeResponseCodeIs(200);
 
-            $responseContent = Craft::$app->getResponse()->content;
-            $response = json_decode($responseContent, true);
-            Assert::assertSame('This is a test runAction error.', $response['message']);
+            $I->seeResponseCodeIs(500);
         }
     }
 }

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -77,8 +77,7 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             );
 
             $I->sendAjaxPostRequest('index.php?action=test-error/access-denied');
-
-            $I->seeResponseCodeIs(403);
+            $I->seeResponseCodeIs(404);
         }
 
         public function testRunActionCatchesError(IntegrationTester $I): void

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -35,13 +35,13 @@ namespace lilthq\craftliltplugintests\integration\controllers {
     use lilthq\craftliltplugin\services\LogsApi;
     use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
     use PHPUnit\Framework\MockObject\MockObject;
-    use RuntimeException;
     use yii\log\FileTarget;
+    use yii\log\Logger;
 
     class PluginControllerCest extends AbstractIntegrationCest
     {
-        private ?string $originalLogPath;
-        private string $testLogPath;
+        private ?Logger $originalLogger;
+        private ?string $testLogPath;
 
         public function _before(IntegrationTester $I): void
         {
@@ -49,15 +49,20 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             Craft::$app->controllerMap['test-error'] = TestErrorController::class;
 
+            $this->originalLogger = Craft::getLogger();
             $this->testLogPath = Craft::getAlias('@storage/logs/test-web.log');
             if (file_exists($this->testLogPath)) {
                 unlink($this->testLogPath);
             }
 
-            /** @var FileTarget $logTarget */
-            $logTarget = Craft::getLogger()->targets['file'];
-            $this->originalLogPath = $logTarget->logFile;
-            $logTarget->logFile = $this->testLogPath;
+            $testLogger = new Logger();
+            $testLogger->targets['test-file'] = new FileTarget([
+                'logFile' => $this->testLogPath,
+                'levels' => ['error', 'warning', 'info', 'trace'],
+                'logVars' => [],
+            ]);
+
+            Craft::setLogger($testLogger);
         }
 
         public function _after(IntegrationTester $I): void
@@ -66,10 +71,11 @@ namespace lilthq\craftliltplugintests\integration\controllers {
 
             unset(Craft::$app->controllerMap['test-error']);
 
-            /** @var FileTarget $logTarget */
-            $logTarget = Craft::getLogger()->targets['file'];
-            $logTarget->logFile = $this->originalLogPath;
-            if (file_exists($this->testLogPath)) {
+            if ($this->originalLogger) {
+                Craft::setLogger($this->originalLogger);
+            }
+
+            if ($this->testLogPath && file_exists($this->testLogPath)) {
                 unlink($this->testLogPath);
             }
 
@@ -136,7 +142,6 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $I->seeResponseContainsJson(['message' => 'This is a test runAction error.']);
 
             $I->openFile($this->testLogPath);
-
             $I->seeInThisFile('Controller error:');
             $I->seeInThisFile('"message":"This is a test runAction error."');
             $I->seeInThisFile('Failed to send log to API. Reason:');

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace lilthq\craftliltplugin\controllers {
+    use yii\web\Response;
+    use RuntimeException;
+
+    class TestErrorController extends PluginController
+    {
+        protected array|int|bool $allowAnonymous = true;
+
+        public function beforeAction($action): bool
+        {
+            if ($action->id === 'error-in-before-action') {
+                throw new RuntimeException('This is a test beforeAction error.');
+            }
+            return parent::beforeAction($action);
+        }
+
+        public function actionErrorInRunAction(): Response
+        {
+            throw new RuntimeException('This is a test runAction error.');
+        }
+    }
+}
+
+namespace lilthq\craftliltplugintests\integration\controllers {
+
+    use Craft;
+    use Exception;
+    use IntegrationTester;
+    use lilthq\craftliltplugin\controllers\TestErrorController;
+    use lilthq\craftliltplugin\Craftliltplugin;
+    use lilthq\craftliltplugin\services\LogsApi;
+    use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
+    use PHPUnit\Framework\MockObject\MockObject;
+    use RuntimeException;
+    use yii\log\FileTarget;
+
+    class PluginControllerCest extends AbstractIntegrationCest
+    {
+        private ?string $originalLogPath;
+        private string $testLogPath;
+
+        public function _before(IntegrationTester $I): void
+        {
+            parent::_before($I);
+
+            Craft::$app->controllerMap['test-error'] = TestErrorController::class;
+
+            $this->testLogPath = Craft::getAlias('@storage/logs/test-web.log');
+            if (file_exists($this->testLogPath)) {
+                unlink($this->testLogPath);
+            }
+
+            /** @var FileTarget $logTarget */
+            $logTarget = Craft::getLogger()->targets['file'];
+            $this->originalLogPath = $logTarget->logFile;
+            $logTarget->logFile = $this->testLogPath;
+        }
+
+        public function _after(IntegrationTester $I): void
+        {
+            parent::_after($I);
+
+            unset(Craft::$app->controllerMap['test-error']);
+
+            /** @var FileTarget $logTarget */
+            $logTarget = Craft::getLogger()->targets['file'];
+            $logTarget->logFile = $this->originalLogPath;
+            if (file_exists($this->testLogPath)) {
+                unlink($this->testLogPath);
+            }
+
+            Craftliltplugin::setInstance(null);
+            Craft::$app->set('craftliltplugin', null);
+        }
+
+        public function testRunActionCatchesAndLogsError(IntegrationTester $I): void
+        {
+            /** @var MockObject|LogsApi $logsApiMock */
+            $logsApiMock = $I->make(LogsApi::class);
+            $logsApiMock->expects($I->once())->method('postLog');
+            $this->mockPluginService($logsApiMock);
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+
+            $I->seeResponseCodeIs(200);
+            $I->seeResponseIsJson();
+            $I->seeResponseContainsJson([
+                'success' => false,
+                'message' => 'This is a test runAction error.',
+            ]);
+
+            $I->openFile($this->testLogPath);
+            $I->seeInThisFile('Controller error:');
+            $I->seeInThisFile('"event":"error-in-run-action"');
+            $I->seeInThisFile('"message":"This is a test runAction error."');
+        }
+
+        public function testBeforeActionCatchesAndLogsError(IntegrationTester $I): void
+        {
+            /** @var MockObject|LogsApi $logsApiMock */
+            $logsApiMock = $I->make(LogsApi::class);
+            $logsApiMock->expects($I->once())
+                ->method('postLog')
+                ->with(
+                    $I->equalTo('error-in-before-action'),
+                    $I->equalTo('This is a test beforeAction error.')
+                );
+            $this->mockPluginService($logsApiMock);
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
+
+            $I->seeResponseCodeIs(404);
+
+            $I->openFile($this->testLogPath);
+            $I->seeInThisFile('Controller error:');
+            $I->seeInThisFile('"event":"error-in-before-action"');
+            $I->seeInThisFile('"message":"This is a test beforeAction error."');
+        }
+
+        public function testHandleErrorLogsApiFailureFailsafe(IntegrationTester $I): void
+        {
+            /** @var MockObject|LogsApi $logsApiMock */
+            $logsApiMock = $I->make(LogsApi::class);
+            $logsApiMock->expects($I->once())
+                ->method('postLog')
+                ->willThrowException(new Exception('Remote API is down.'));
+            $this->mockPluginService($logsApiMock);
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+
+            $I->seeResponseCodeIs(200);
+            $I->seeResponseContainsJson(['message' => 'This is a test runAction error.']);
+
+            $I->openFile($this->testLogPath);
+
+            $I->seeInThisFile('Controller error:');
+            $I->seeInThisFile('"message":"This is a test runAction error."');
+            $I->seeInThisFile('Failed to send log to API. Reason:');
+            $I->seeInThisFile('"message":"Remote API is down."');
+        }
+
+        private function mockPluginService(LogsApi|MockObject $logsApiMock): void
+        {
+            $pluginMock = $this->createMock(Craftliltplugin::class);
+            $pluginMock->logsApi = $logsApiMock;
+            Craftliltplugin::setInstance($pluginMock);
+        }
+    }
+}

--- a/tests/integration/controllers/PluginControllerCest.php
+++ b/tests/integration/controllers/PluginControllerCest.php
@@ -24,6 +24,11 @@ namespace lilthq\craftliltplugin\controllers {
             {
                 throw new RuntimeException('This is a test runAction error.');
             }
+
+            public function actionErrorViaEvent(): Response
+            {
+                return $this->asJson(['success' => true]);
+            }
         }
     }
 }
@@ -35,6 +40,8 @@ namespace lilthq\craftliltplugintests\integration\controllers {
     use lilthq\craftliltplugin\controllers\TestErrorController;
     use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
     use PHPUnit\Framework\Assert;
+    use yii\base\Event;
+    use craft\web\Controller;
 
     class PluginControllerCest extends AbstractIntegrationCest
     {
@@ -42,15 +49,27 @@ namespace lilthq\craftliltplugintests\integration\controllers {
         {
             parent::_before($I);
             Craft::$app->controllerMap['test-error'] = TestErrorController::class;
+
+            Event::on(
+                Controller::class,
+                Controller::EVENT_BEFORE_ACTION,
+                function($event) {
+                    if ($event->sender instanceof TestErrorController && $event->action->id === 'error-via-event') {
+                        throw new \RuntimeException('Error from event handler');
+                    }
+                }
+            );
         }
 
         public function _after(IntegrationTester $I): void
         {
             parent::_after($I);
             unset(Craft::$app->controllerMap['test-error']);
+
+            Event::off(Controller::class, Controller::EVENT_BEFORE_ACTION);
         }
 
-        public function testBeforeActionCatchesError(IntegrationTester $I): void
+        public function testRunActionCatchesBeforeActionErrorFromChild(IntegrationTester $I): void
         {
             $I->expectLogPostRequest(
                 '/api/v1.0/logs',
@@ -72,26 +91,20 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             );
         }
 
-        public function testBeforeActionCatchesInternalError(IntegrationTester $I): void
+        public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
         {
-            $request = Craft::$app->getRequest();
-            $request->enableCsrfValidation = true;
-
             $I->expectLogPostRequest(
                 '/api/v1.0/logs',
-                'Unable to verify your data submission.',
-                200
+                'This is a test runAction error.',
+                500
             );
 
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action', []);
-
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
             $I->seeResponseCodeIs(200);
-            $response = json_decode(Craft::$app->getResponse()->content, true);
 
-            Assert::assertFalse($response['success']);
+            $responseContent = Craft::$app->getResponse()->content;
+            $response = json_decode($responseContent, true);
             Assert::assertSame('This is a test runAction error.', $response['message']);
-
-            $request->enableCsrfValidation = false;
         }
 
         public function testRunActionCatchesError(IntegrationTester $I): void
@@ -109,26 +122,34 @@ namespace lilthq\craftliltplugintests\integration\controllers {
             $response = json_decode($responseContent, true);
 
             Assert::assertIsArray($response);
-            Assert::assertArrayHasKey('success', $response);
-            Assert::assertArrayHasKey('message', $response);
             Assert::assertFalse($response['success']);
             Assert::assertSame('This is a test runAction error.', $response['message']);
         }
 
-        public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
+        public function testBeforeActionCatchesInternalFrameworkError(IntegrationTester $I): void
         {
             $I->expectLogPostRequest(
                 '/api/v1.0/logs',
-                'This is a test runAction error.',
-                500
+                'Error from event handler',
+                200
             );
 
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-            $I->seeResponseCodeIs(200);
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'Unable to resolve the request: test-error/error-via-event',
+                200
+            );
 
-            $responseContent = Craft::$app->getResponse()->content;
-            $response = json_decode($responseContent, true);
-            Assert::assertSame('This is a test runAction error.', $response['message']);
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-via-event');
+
+            $I->seeResponseCodeIs(200);
+            $response = json_decode(Craft::$app->getResponse()->content, true);
+
+            Assert::assertFalse($response['success']);
+            Assert::assertSame(
+                'Unable to resolve the request: test-error/error-via-event',
+                $response['message']
+            );
         }
     }
 }

--- a/tests/integration/controllers/job/PostCreateJobControllerCest.php
+++ b/tests/integration/controllers/job/PostCreateJobControllerCest.php
@@ -2,98 +2,95 @@
 
 declare(strict_types=1);
 
-namespace lilthq\craftliltplugintests\integration\controllers\job;
+namespace lilthq\craftliltplugin\controllers {
 
-use Codeception\Exception\ModuleException;
-use Craft;
-use craft\elements\Entry;
-use craft\errors\MissingComponentException;
-use IntegrationTester;
-use LiltConnectorSDK\Model\SettingsResponse;
-use lilthq\craftliltplugin\controllers\job\PostCreateJobController;
-use lilthq\craftliltplugin\Craftliltplugin;
-use lilthq\craftliltplugin\elements\Job;
-use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
-use lilthq\tests\fixtures\EntriesFixture;
-use PHPUnit\Framework\Assert;
-use yii\base\InvalidConfigException;
-use yii\db\Exception;
+    use RuntimeException;
+    use yii\web\Response;
 
-class PostCreateJobControllerCest extends AbstractIntegrationCest
-{
-    public function _fixtures(): array
+    class TestErrorController extends PluginController
     {
-        return [
-            'entries' => [
-                'class' => EntriesFixture::class,
-            ]
-        ];
-    }
+        protected array|int|bool $allowAnonymous = true;
 
-    /**
-     * @throws InvalidConfigException
-     */
-    private function getController(): PostCreateJobController
-    {
-        Craftliltplugin::getInstance()->controllerNamespace = 'lilthq\craftliltplugin\controllers';
-        return Craft::$app->createController('craft-lilt-plugin/job/post-create-job/invoke')[0];
-    }
+        public function beforeAction($action): bool
+        {
+            if ($action->id === 'error-in-before-action') {
+                throw new RuntimeException('This is a test beforeAction error.');
+            }
+            return parent::beforeAction($action);
+        }
 
-    /**
-     * @throws MissingComponentException
-     * @throws InvalidConfigException
-     * @throws Exception|ModuleException
-     */
-    public function testCreateJob(IntegrationTester $I): void
-    {
-        $element = Entry::findOne(['authorId' => 1]);
-
-        $user = Craft::$app->getUsers()->getUserById(1);
-        $I->amLoggedInAs($user);
-
-        $I->sendAjaxPostRequest(
-            '?p=admin/craft-lilt-plugin/job/create',
-            [
-                'csrf' => Craft::$app->getRequest()->getCsrfToken(true),
-                'entries' => json_encode([$element->id]),
-                'title' => 'Awesome test job',
-                'sourceSite' => Craftliltplugin::getInstance()->languageMapper->getSiteIdByLanguage('en-US'),
-                'translationWorkflow' => strtolower(SettingsResponse::LILT_TRANSLATION_WORKFLOW_INSTANT),
-                'targetSiteIds' => '*',
-            ]
-        );
-        $I->seeResponseCodeIs(302);
-
-        $job = Job::find()
-            ->orderBy(['id' => SORT_DESC])
-            ->one();
-
-        $I->seeHeader(
-            'x-redirect',
-            sprintf('https://test.craftcms.test:80/index.php?p=admin/craft-lilt-plugin/job/edit/%d&site=default', $job->id)
-        );
-
-        Assert::assertSame('Awesome test job', $job->title);
-        Assert::assertSame([$element->id], $job->getElementIds());
-        Assert::assertSame('instant', $job->translationWorkflow);
-        Assert::assertSame(
-            Craftliltplugin::getInstance()->languageMapper->getSiteIdByLanguage('en-US'),
-            $job->sourceSiteId
-        );
-        Assert::assertSame(
-            'en-US',
-            $job->sourceSiteLanguage
-        );
-
-        Assert::assertCount(3, $job->getTargetSiteIds());
-
-        Assert::assertEquals(
-            ['de-DE', 'es-ES', 'ru-RU'],
-            Craftliltplugin::getInstance()
-                ->languageMapper
-                ->getLanguagesBySiteIds(
-                    $job->getTargetSiteIds()
-                )
-        );
+        public function actionErrorInRunAction(): Response
+        {
+            throw new RuntimeException('This is a test runAction error.');
+        }
     }
 }
+
+namespace lilthq\craftliltplugintests\integration\controllers {
+
+    use Craft;
+    use IntegrationTester;
+    use lilthq\craftliltplugin\controllers\TestErrorController;
+    use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
+
+    class PluginControllerCest extends AbstractIntegrationCest
+    {
+        public function _before(IntegrationTester $I): void
+        {
+            parent::_before($I);
+            Craft::$app->controllerMap['test-error'] = TestErrorController::class;
+        }
+
+        public function _after(IntegrationTester $I): void
+        {
+            parent::_after($I);
+            unset(Craft::$app->controllerMap['test-error']);
+        }
+
+        public function testRunActionCatchesError(IntegrationTester $I): void
+        {
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'This is a test runAction error.',
+                200
+            );
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+
+            $I->seeResponseCodeIs(200);
+            $I->seeResponseIsJson();
+            $I->seeResponseContainsJson([
+                'success' => false,
+                'message' => 'This is a test runAction error.',
+            ]);
+        }
+
+        public function testBeforeActionCatchesError(IntegrationTester $I): void
+        {
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'This is a test beforeAction error.',
+                200
+            );
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
+
+            $I->seeResponseCodeIs(404);
+        }
+
+        public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
+        {
+            $I->expectLogPostRequest(
+                '/api/v1.0/logs',
+                'This is a test runAction error.',
+                500
+            );
+
+            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
+
+            $I->seeResponseCodeIs(200);
+            $I->seeResponseContainsJson(['message' => 'This is a test runAction error.']);
+        }
+    }
+}
+

--- a/tests/integration/controllers/job/PostCreateJobControllerCest.php
+++ b/tests/integration/controllers/job/PostCreateJobControllerCest.php
@@ -2,95 +2,98 @@
 
 declare(strict_types=1);
 
-namespace lilthq\craftliltplugin\controllers {
+namespace lilthq\craftliltplugintests\integration\controllers\job;
 
-    use RuntimeException;
-    use yii\web\Response;
+use Codeception\Exception\ModuleException;
+use Craft;
+use craft\elements\Entry;
+use craft\errors\MissingComponentException;
+use IntegrationTester;
+use LiltConnectorSDK\Model\SettingsResponse;
+use lilthq\craftliltplugin\controllers\job\PostCreateJobController;
+use lilthq\craftliltplugin\Craftliltplugin;
+use lilthq\craftliltplugin\elements\Job;
+use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
+use lilthq\tests\fixtures\EntriesFixture;
+use PHPUnit\Framework\Assert;
+use yii\base\InvalidConfigException;
+use yii\db\Exception;
 
-    class TestErrorController extends PluginController
+class PostCreateJobControllerCest extends AbstractIntegrationCest
+{
+    public function _fixtures(): array
     {
-        protected array|int|bool $allowAnonymous = true;
+        return [
+            'entries' => [
+                'class' => EntriesFixture::class,
+            ]
+        ];
+    }
 
-        public function beforeAction($action): bool
-        {
-            if ($action->id === 'error-in-before-action') {
-                throw new RuntimeException('This is a test beforeAction error.');
-            }
-            return parent::beforeAction($action);
-        }
+    /**
+     * @throws InvalidConfigException
+     */
+    private function getController(): PostCreateJobController
+    {
+        Craftliltplugin::getInstance()->controllerNamespace = 'lilthq\craftliltplugin\controllers';
+        return Craft::$app->createController('craft-lilt-plugin/job/post-create-job/invoke')[0];
+    }
 
-        public function actionErrorInRunAction(): Response
-        {
-            throw new RuntimeException('This is a test runAction error.');
-        }
+    /**
+     * @throws MissingComponentException
+     * @throws InvalidConfigException
+     * @throws Exception|ModuleException
+     */
+    public function testCreateJob(IntegrationTester $I): void
+    {
+        $element = Entry::findOne(['authorId' => 1]);
+
+        $user = Craft::$app->getUsers()->getUserById(1);
+        $I->amLoggedInAs($user);
+
+        $I->sendAjaxPostRequest(
+            '?p=admin/craft-lilt-plugin/job/create',
+            [
+                'csrf' => Craft::$app->getRequest()->getCsrfToken(true),
+                'entries' => json_encode([$element->id]),
+                'title' => 'Awesome test job',
+                'sourceSite' => Craftliltplugin::getInstance()->languageMapper->getSiteIdByLanguage('en-US'),
+                'translationWorkflow' => strtolower(SettingsResponse::LILT_TRANSLATION_WORKFLOW_INSTANT),
+                'targetSiteIds' => '*',
+            ]
+        );
+        $I->seeResponseCodeIs(302);
+
+        $job = Job::find()
+            ->orderBy(['id' => SORT_DESC])
+            ->one();
+
+        $I->seeHeader(
+            'x-redirect',
+            sprintf('https://test.craftcms.test:80/index.php?p=admin/craft-lilt-plugin/job/edit/%d&site=default', $job->id)
+        );
+
+        Assert::assertSame('Awesome test job', $job->title);
+        Assert::assertSame([$element->id], $job->getElementIds());
+        Assert::assertSame('instant', $job->translationWorkflow);
+        Assert::assertSame(
+            Craftliltplugin::getInstance()->languageMapper->getSiteIdByLanguage('en-US'),
+            $job->sourceSiteId
+        );
+        Assert::assertSame(
+            'en-US',
+            $job->sourceSiteLanguage
+        );
+
+        Assert::assertCount(3, $job->getTargetSiteIds());
+
+        Assert::assertEquals(
+            ['de-DE', 'es-ES', 'ru-RU'],
+            Craftliltplugin::getInstance()
+                ->languageMapper
+                ->getLanguagesBySiteIds(
+                    $job->getTargetSiteIds()
+                )
+        );
     }
 }
-
-namespace lilthq\craftliltplugintests\integration\controllers {
-
-    use Craft;
-    use IntegrationTester;
-    use lilthq\craftliltplugin\controllers\TestErrorController;
-    use lilthq\craftliltplugintests\integration\AbstractIntegrationCest;
-
-    class PluginControllerCest extends AbstractIntegrationCest
-    {
-        public function _before(IntegrationTester $I): void
-        {
-            parent::_before($I);
-            Craft::$app->controllerMap['test-error'] = TestErrorController::class;
-        }
-
-        public function _after(IntegrationTester $I): void
-        {
-            parent::_after($I);
-            unset(Craft::$app->controllerMap['test-error']);
-        }
-
-        public function testRunActionCatchesError(IntegrationTester $I): void
-        {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'This is a test runAction error.',
-                200
-            );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-
-            $I->seeResponseCodeIs(200);
-            $I->seeResponseIsJson();
-            $I->seeResponseContainsJson([
-                'success' => false,
-                'message' => 'This is a test runAction error.',
-            ]);
-        }
-
-        public function testBeforeActionCatchesError(IntegrationTester $I): void
-        {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'This is a test beforeAction error.',
-                200
-            );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-before-action');
-
-            $I->seeResponseCodeIs(404);
-        }
-
-        public function testApiLoggingFailureDoesNotAffectUserResponse(IntegrationTester $I): void
-        {
-            $I->expectLogPostRequest(
-                '/api/v1.0/logs',
-                'This is a test runAction error.',
-                500
-            );
-
-            $I->sendAjaxPostRequest('index.php?action=test-error/error-in-run-action');
-
-            $I->seeResponseCodeIs(200);
-            $I->seeResponseContainsJson(['message' => 'This is a test runAction error.']);
-        }
-    }
-}
-


### PR DESCRIPTION
## BLOCKED
This is currently blocked until the PHP SDK has been version bumped. [ENG-25109](https://lilt.atlassian.net/browse/ENG-25109)

---

[ENG-24482](https://lilt.atlassian.net/browse/ENG-24482) - Add non-EMC logging to the Craft CMS plugin

**This will also require an update to [lilt-connector-sdk-php](https://github.com/lilt/lilt-connector-sdk-php) to incorporate the new POST /logs endpoint.**

This implements Yii's `beforeAction` and `runAction` lifecycle events in a custom `PluginController` that other controllers should extend instead of directly extending `craft\web\Controller`.

By catching errors in these lifecycles, we catch anything that prevents an operation from taking place in Craft CMS, thus preventing interactions to the Craft connector, so that we can send error logs to the new POST /logs endpoint in the Plugin API.

[ENG-24482]: https://lilt.atlassian.net/browse/ENG-24482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ENG-25109]: https://lilt.atlassian.net/browse/ENG-25109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ